### PR TITLE
WIP: GB-190 Weaving on shader execution for ShaderToggler Compatibility

### DIFF
--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -103,6 +103,15 @@ void DirectX10Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime)
         latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
     }
     ImGui::TextUnformatted(latencyModeDisplay.c_str());
+
+    // Log when we are weaving
+    std::string weavingTimingDisplay = "Weaving timing: ";
+    if(weaveOnShader) {
+        weavingTimingDisplay += "after SuperDepth3D shader is drawn";
+    } else {
+        weavingTimingDisplay += "after all ReShade effects are finished";
+    }
+    ImGui::TextUnformatted(weavingTimingDisplay.c_str());
 }
 
 void DirectX10Weaver::draw_debug_overlay(reshade::api::effect_runtime* runtime)

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -126,6 +126,15 @@ void DirectX11Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime)
         latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
     }
     ImGui::TextUnformatted(latencyModeDisplay.c_str());
+
+    // Log when we are weaving
+    std::string weavingTimingDisplay = "Weaving timing: ";
+    if(weaveOnShader) {
+        weavingTimingDisplay += "after SuperDepth3D shader is drawn";
+    } else {
+        weavingTimingDisplay += "after all ReShade effects are finished";
+    }
+    ImGui::TextUnformatted(weavingTimingDisplay.c_str());
 }
 
 void DirectX11Weaver::draw_sr_settings_overlay(reshade::api::effect_runtime* runtime)

--- a/gamebridge_reshade/src/directx12weaver.cpp
+++ b/gamebridge_reshade/src/directx12weaver.cpp
@@ -85,6 +85,15 @@ void DirectX12Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime)
         latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
     }
     ImGui::TextUnformatted(latencyModeDisplay.c_str());
+
+    // Log when we are weaving
+    std::string weavingTimingDisplay = "Weaving timing: ";
+    if(weaveOnShader) {
+        weavingTimingDisplay += "after SuperDepth3D shader is drawn";
+    } else {
+        weavingTimingDisplay += "after all ReShade effects are finished";
+    }
+    ImGui::TextUnformatted(weavingTimingDisplay.c_str());
 }
 
 void DirectX12Weaver::draw_debug_overlay(reshade::api::effect_runtime* runtime)

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -91,6 +91,15 @@ void DirectX9Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime) 
         latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
     }
     ImGui::TextUnformatted(latencyModeDisplay.c_str());
+
+    // Log when we are weaving
+    std::string weavingTimingDisplay = "Weaving timing: ";
+    if(weaveOnShader) {
+        weavingTimingDisplay += "after SuperDepth3D shader is drawn";
+    } else {
+        weavingTimingDisplay += "after all ReShade effects are finished";
+    }
+    ImGui::TextUnformatted(weavingTimingDisplay.c_str());
 }
 
 void DirectX9Weaver::draw_debug_overlay(reshade::api::effect_runtime* runtime)

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -16,11 +16,13 @@ HotKeyManager::HotKeyManager()
     HotKey toggle3D = HotKey(false, shortcutType::toggle_3D, 0x33, false, false, true);
     HotKey toggleLensAnd3D = HotKey(false, shortcutType::toggle_lens_and_3D, 0x34, false, false, true);
     HotKey toggleLatencyMode = HotKey(false, shortcutType::toggle_latency_mode, 0x35, false, false, true);
+    HotKey toggleWeaveOnShader = HotKey(false, shortcutType::toggle_weave_on_shader, 0x36, false, false, true);
     registered_hot_keys.push_back(toggleSRKey);
     registered_hot_keys.push_back(toggleLensKey);
     registered_hot_keys.push_back(toggle3D);
     registered_hot_keys.push_back(toggleLensAnd3D);
     registered_hot_keys.push_back(toggleLatencyMode);
+    registered_hot_keys.push_back(toggleWeaveOnShader);
 }
 
 bool checkModifierKeys(HotKey hotKey, reshade::api::effect_runtime* runtime) {

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -34,6 +34,8 @@ public:
 
     int32_t get_concatinated_reshade_version();
 
+    bool weaveOnShader = false;
+
     virtual void draw_debug_overlay(reshade::api::effect_runtime* runtime) = 0;
     virtual void draw_sr_settings_overlay(reshade::api::effect_runtime* runtime) = 0;
     virtual void draw_settings_overlay(reshade::api::effect_runtime* runtime) = 0;

--- a/gamebridge_reshade/src/pch.h
+++ b/gamebridge_reshade/src/pch.h
@@ -34,6 +34,6 @@
 #include "sr/types.h"
 
 // Global shortcut definition
-enum shortcutType { toggle_SR, toggle_lens, toggle_3D, toggle_lens_and_3D, toggle_latency_mode };
+enum shortcutType { toggle_weave_on_shader, toggle_SR, toggle_lens, toggle_3D, toggle_lens_and_3D, toggle_latency_mode };
 
 #endif //PCH_H


### PR DESCRIPTION
Doesn't work with ShaderToggler the way we want yet but does weave after SD3D execution.

We want to weave right after SuperDepth3D so that we can exclude the UI pass from the weaved image. This will mess with the latency of the weaver but it will be worth it for the improved visuals, especially at higher framerates.