### PR TITLE
Feature/configurable hotkeys

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,24 @@ This application currently has one QoL feature implemented which are the shortcu
 
     Stick to the default setting if you’re not sure.
 
-These shortcuts were mostly implemented for debugging, they might not be useful to everyone but I’ve included them here to avoid confusion. Later, these hotkeys are planned to be customizable, but they are static for this release.
+These shortcuts were mostly implemented for debugging, they might not be useful to everyone but I’ve included them here to avoid confusion.
+
+## Changing Shortcut Key Bindings
+When loading a game using Game Bridge and no shortcut bindings are found, the default ones will be loaded into the `ReShade.ini` file for that game.
+These bindings look like this:
+
+``` .ini
+[3DGameBridge]
+toggle_3d_key=0x33;ctrl
+toggle_latency_mode_key=0x35;ctrl
+toggle_lens_and_3d_key=0x34;ctrl
+toggle_lens_key=0x32;ctrl
+toggle_sr_key=0x31;ctrl;shift;alt
+```
+
+Key bindings are structured like this: `[hex_keycode];[modifier_key];[modifier_key];[modifier_key]`<br/>
+- The supported keycodes can be found in the "value" column [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes).
+- The supported modifier keys are: `shift`, `ctrl` and `alt`
 
 ## 
 

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -265,7 +265,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     // Todo: Move these hard-coded hotkeys to user-definable hotkeys in the .ini file
     // Register some standard hotkeys
     if (hotKey_manager == nullptr) {
-        hotKey_manager = new HotKeyManager(runtime);
+        hotKey_manager = new HotKeyManager();
     }
 
     try {

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -265,7 +265,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     // Todo: Move these hard-coded hotkeys to user-definable hotkeys in the .ini file
     // Register some standard hotkeys
     if (hotKey_manager == nullptr) {
-        hotKey_manager = new HotKeyManager();
+        hotKey_manager = new HotKeyManager(runtime);
     }
 
     try {

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -23,6 +23,8 @@ private:
     std::vector<HotKey> registered_hot_keys;
 
     // Writes hotkeys if they are not present in the ReShade.ini file
+    void load_default_hotkeys();
+
     static void write_missing_hotkeys();
 
     // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -14,7 +14,7 @@
 
 class HotKeyManager {
 public:
-    HotKeyManager();
+    explicit HotKeyManager(reshade::api::effect_runtime* runtime);
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
     // Todo: Implement a way to edit and create now hotkeys?
     void edit_hot_key(uint8_t hot_key_id);
@@ -22,4 +22,16 @@ public:
 private:
     // Todo: We should define these in a .ini file eventually.
     std::vector<HotKey> registered_hot_keys;
+
+    // Keys are stored in the config like so:
+    // [3DGameBridge]
+    // toggle_sr_key=0x31;shift;alt;ctrl
+    // toggle_sr_key=0x31;ctrl
+    // toggle_sr_key=0x31;
+    //
+    // The following keys are available: toggle_sr_key, toggle_lens_key, toggle_3d_key, toggle_lens_and_3d_key, toggle_latency_mode_key
+    //
+    // Method to read a specific key from the ReShade config.
+    // Returns an instance of the hotkey class based on the read config values.
+    HotKey read_from_config(bool default_enabled, std::string key, shortcutType shortcut);
 };

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -16,22 +16,25 @@ class HotKeyManager {
 public:
     explicit HotKeyManager(reshade::api::effect_runtime* runtime);
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
-    // Todo: Implement a way to edit and create now hotkeys?
+    // Todo: Implement a way to edit and create new hotkeys?
     void edit_hot_key(uint8_t hot_key_id);
 
 private:
-    // Todo: We should define these in a .ini file eventually.
     std::vector<HotKey> registered_hot_keys;
+
+    // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.
+    static void removeUnwantedNulls(std::vector<char>& vec);
 
     // Keys are stored in the config like so:
     // [3DGameBridge]
     // toggle_sr_key=0x31;shift;alt;ctrl
     // toggle_sr_key=0x31;ctrl
     // toggle_sr_key=0x31;
+    // toggle_sr_key=0x31
     //
     // The following keys are available: toggle_sr_key, toggle_lens_key, toggle_3d_key, toggle_lens_and_3d_key, toggle_latency_mode_key
     //
     // Method to read a specific key from the ReShade config.
     // Returns an instance of the hotkey class based on the read config values.
-    HotKey read_from_config(bool default_enabled, std::string key, shortcutType shortcut);
+    static HotKey read_from_config(bool default_enabled, const std::string& key, shortcutType shortcut);
 };

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -22,6 +22,9 @@ public:
 private:
     std::vector<HotKey> registered_hot_keys;
 
+    // Writes hotkeys if they are not present in the ReShade.ini file
+    static void write_missing_hotkeys();
+
     // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.
     static void removeUnwantedNulls(std::vector<char>& vec);
 

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -14,7 +14,7 @@
 
 class HotKeyManager {
 public:
-    explicit HotKeyManager(reshade::api::effect_runtime* runtime);
+    HotKeyManager();
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
     // Todo: Implement a way to edit and create new hotkeys?
     void edit_hot_key(uint8_t hot_key_id);

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -65,7 +65,7 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
     throw std::runtime_error("Unable to read key from config");
 }
 
-HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
+HotKeyManager::HotKeyManager() {
     // Create some default hotkeys.
     try {
         registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -69,16 +69,17 @@ HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Create some default hotkeys.
     try {
         registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
-        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+        registered_hot_keys.push_back(read_from_config(true, "toggle_lens_key", TOGGLE_LENS));
         registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
         registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
         registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
     }
     catch (std::runtime_error &e) {
         // Couldn't find the config value, let's write the default in the .ini
-        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing defaults...";
+        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing/loading defaults...";
         reshade::log_message(reshade::log_level::warning, error_msg.c_str());
         write_missing_hotkeys();
+        load_default_hotkeys();
     }
 }
 
@@ -153,4 +154,13 @@ void HotKeyManager::write_missing_hotkeys() {
     if (value_size <= 0) {
         reshade::set_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", "0x35\;ctrl");
     }
+}
+
+void HotKeyManager::load_default_hotkeys() {
+    registered_hot_keys.erase(registered_hot_keys.begin(), registered_hot_keys.end());
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true));
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true));
 }

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -7,19 +7,56 @@
 
 #include "hotkeyManager.h"
 
-HotKeyManager::HotKeyManager() {
+HotKey HotKeyManager::read_from_config(bool default_enabled, std::string key, shortcutType shortcut) {
+    size_t value_size;
+    reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), nullptr, &value_size);
+    if (value_size > 0) {
+        // Get the value from the config
+        std::vector<char> value(value_size);
+        reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
+        // Convert read value to lower case string
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c){ return std::tolower(c); });
+        std::string str(value.begin(), value.end());
+        // Create the hotkey
+        // Todo: Seems to preemptively split the input on the first ";" already.
+        int found_key = 0;
+        try {
+            // Todo: It should also work if there is not ";" in the config
+            found_key = std::stoi(str.substr(0, str.find(';')));
+        }
+        catch (...)
+        {
+            std::string error_msg = "Unable to read hotkey from config file for hotkey: ";
+            error_msg += key;
+            error_msg += ". Please ensure that you use the keycode table: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes";
+            reshade::log_message(reshade::log_level::error, error_msg.c_str());
+        }
+        HotKey created_key = HotKey(default_enabled, shortcut, found_key, str.find("shift") != std::string::npos, str.find("alt") != std::string::npos, str.find("ctrl") != str.find("shift") != std::string::npos);
+        return created_key;
+    }
+}
+
+HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Todo: Could be prettier
     // Create some default hotkeys.
-    HotKey toggle_sr_key = HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true);
-    HotKey toggle_lens_key = HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true);
-    HotKey toggle_3d = HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true);
-    HotKey toggle_lens_and_3d = HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true);
-    HotKey toggle_latency_mode = HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true);
-    registered_hot_keys.push_back(toggle_sr_key);
-    registered_hot_keys.push_back(toggle_lens_key);
-    registered_hot_keys.push_back(toggle_3d);
-    registered_hot_keys.push_back(toggle_lens_and_3d);
-    registered_hot_keys.push_back(toggle_latency_mode);
+//    size_t value_size;
+//    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", nullptr, &value_size);
+//    if (value_size > 0) {
+//        std::vector<char> value(value_size);
+//        reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", value.data(), &value_size);
+//    }
+
+//    HotKey toggle_sr_key = HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true);
+//    HotKey toggle_lens_key = HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true);
+//    HotKey toggle_3d = HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true);
+//    HotKey toggle_lens_and_3d = HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true);
+//    HotKey toggle_latency_mode = HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true);
+    registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
 }
 
 bool check_modifier_keys(HotKey hotKey, reshade::api::effect_runtime* runtime) {

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -62,15 +62,24 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
         }
         return created_key;
     }
+    throw std::runtime_error("Unable to read key from config");
 }
 
 HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Create some default hotkeys.
-    registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+    try {
+        registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+    }
+    catch (std::runtime_error &e) {
+        // Couldn't find the config value, let's write the default in the .ini
+        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing defaults...";
+        reshade::log_message(reshade::log_level::warning, error_msg.c_str());
+        write_missing_hotkeys();
+    }
 }
 
 bool check_modifier_keys(HotKey hotKey, reshade::api::effect_runtime* runtime) {
@@ -116,4 +125,32 @@ std::map<shortcutType, bool> HotKeyManager::check_hot_keys(reshade::api::effect_
 
 void HotKeyManager::edit_hot_key(uint8_t hot_key_id) {
 
+}
+
+void HotKeyManager::write_missing_hotkeys() {
+    size_t value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_sr_key", "0x31\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_key", "0x32\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_3d_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_3d_key", "0x33\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", "0x34\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", "0x35\;ctrl");
+    }
 }


### PR DESCRIPTION
Hotkeys can now be re-assigned using the ReShade.ini file.
If they are missing from your file, they will be written and can be used on a subsequent boot.
It loads default hotkey bindings if it is unable to read all of the hotkeys.