### PR TITLE
Feature/disable weaving without user + configurable hotkeys

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,7 +68,24 @@ This application currently has one QoL feature implemented which are the shortcu
 
     Stick to the default setting if you’re not sure.
 
-These shortcuts were mostly implemented for debugging, they might not be useful to everyone but I’ve included them here to avoid confusion. Later, these hotkeys are planned to be customizable, but they are static for this release.
+These shortcuts were mostly implemented for debugging, they might not be useful to everyone but I’ve included them here to avoid confusion.
+
+## Changing Shortcut Key Bindings
+When loading a game using Game Bridge and no shortcut bindings are found, the default ones will be loaded into the `ReShade.ini` file for that game.
+These bindings look like this:
+
+``` .ini
+[3DGameBridge]
+toggle_3d_key=0x33;ctrl
+toggle_latency_mode_key=0x35;ctrl
+toggle_lens_and_3d_key=0x34;ctrl
+toggle_lens_key=0x32;ctrl
+toggle_sr_key=0x31;ctrl;shift;alt
+```
+
+Key bindings are structured like this: `[hex_keycode];[modifier_key];[modifier_key];[modifier_key]`<br/>
+- The supported keycodes can be found in the "value" column [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes).
+- The supported modifier keys are: `shift`, `ctrl` and `alt`
 
 ## 
 

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -27,6 +27,8 @@ add_library(${PROJECT_NAME} SHARED
 	src/systemEventMonitor.h
 	src/configManager.h
 	src/configManager.cpp
+		src/versioncomparer.cpp
+		src/versioncomparer.h
 )
 
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -23,6 +23,8 @@ add_library(${PROJECT_NAME} SHARED
     src/hotkeymanager.cpp
     src/hotkeymanager.h
     src/delayLoader.h
+	src/systemEventMonitor.cpp
+	src/systemEventMonitor.h
 )
 
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -27,8 +27,8 @@ add_library(${PROJECT_NAME} SHARED
 	src/systemEventMonitor.h
 	src/configManager.h
 	src/configManager.cpp
-		src/versioncomparer.cpp
-		src/versioncomparer.h
+    src/versioncomparer.cpp
+    src/versioncomparer.h
 )
 
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
@@ -82,4 +82,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
  target_link_options(${PROJECT_NAME} PRIVATE "/DELAYLOAD:SimulatedRealityCore${BUILD_PLATFORM}.dll")
  target_link_options(${PROJECT_NAME} PRIVATE "/DELAYLOAD:SimulatedRealityDirectX${BUILD_PLATFORM}.dll")
  target_link_options(${PROJECT_NAME} PRIVATE "/DELAYLOAD:SimulatedRealityOpenGL${BUILD_PLATFORM}.dll")
+ target_link_options(${PROJECT_NAME} PRIVATE "/DELAYLOAD:SimulatedReality${BUILD_PLATFORM}.dll")
  target_link_options(${PROJECT_NAME} PRIVATE "/DELAYLOAD:opencv_world343.dll")

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -25,6 +25,8 @@ add_library(${PROJECT_NAME} SHARED
     src/delayLoader.h
 	src/systemEventMonitor.cpp
 	src/systemEventMonitor.h
+	src/configManager.h
+	src/configManager.cpp
 )
 
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -27,8 +27,9 @@ add_library(${PROJECT_NAME} SHARED
 	src/systemEventMonitor.h
 	src/configManager.h
 	src/configManager.cpp
-    src/versioncomparer.cpp
-    src/versioncomparer.h
+	src/versioncomparer.cpp
+	src/versioncomparer.h
+	src/gbConstants.h
 )
 
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)

--- a/gamebridge_reshade/src/VersionComparer.cpp
+++ b/gamebridge_reshade/src/VersionComparer.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-bool VersionComparer::isVersionNewer(const char *runningVersionString, int major, int minor, int patch) {
+bool VersionComparer::is_version_newer(const char *runningVersionString, int major, int minor, int patch) {
     // Parse the version string
     std::string version(runningVersionString);
     std::vector<int> versionParts;
@@ -29,8 +29,9 @@ bool VersionComparer::isVersionNewer(const char *runningVersionString, int major
 
     // Ensure we have at least MAJOR.MINOR.PATCH
     if (versionParts.size() < 3) {
-     // Todo: Replace with reshade log.
-     // std::cerr << "Invalid version format: " << version << std::endl;
+     std::string message = "Invalid SR version format: ";
+     message += version;
+     reshade::log_message(reshade::log_level::warning, message.c_str());
      return false;
     }
 

--- a/gamebridge_reshade/src/VersionComparer.cpp
+++ b/gamebridge_reshade/src/VersionComparer.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#include "VersionComparer.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+bool VersionComparer::isVersionNewer(const char *runningVersionString, int major, int minor, int patch) {
+    // Parse the version string
+    std::string version(runningVersionString);
+    std::vector<int> versionParts;
+    std::istringstream ss(version);
+    std::string token;
+
+    // Split the version string by '.'
+    while (std::getline(ss, token, '.')) {
+     try {
+      versionParts.push_back(std::stoi(token));
+     } catch (...) {
+      break; // Stop if we encounter GIT_HASH or invalid parts
+     }
+    }
+
+    // Ensure we have at least MAJOR.MINOR.PATCH
+    if (versionParts.size() < 3) {
+     // Todo: Replace with reshade log.
+     // std::cerr << "Invalid version format: " << version << std::endl;
+     return false;
+    }
+
+    // Extract the components
+    int runningMajor = versionParts[0];
+    int runningMinor = versionParts[1];
+    int runningPatch = versionParts[2];
+
+    // Compare versions
+    if (runningMajor > major) return true;
+    if (runningMajor < major) return false;
+    if (runningMinor > minor) return true;
+    if (runningMinor < minor) return false;
+    if (runningPatch > patch) return true;
+    if (runningPatch < patch) return false;
+
+    // If we reach here, the versions are equal
+    return false;
+}

--- a/gamebridge_reshade/src/VersionComparer.h
+++ b/gamebridge_reshade/src/VersionComparer.h
@@ -1,0 +1,21 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#ifndef VERSIONCOMPARER_H
+#define VERSIONCOMPARER_H
+
+
+
+class VersionComparer {
+public:
+    static bool isVersionNewer(const char* versionString, int major, int minor, int patch);
+
+};
+
+
+
+#endif //VERSIONCOMPARER_H

--- a/gamebridge_reshade/src/VersionComparer.h
+++ b/gamebridge_reshade/src/VersionComparer.h
@@ -5,17 +5,11 @@
  * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
  */
 
-#ifndef VERSIONCOMPARER_H
-#define VERSIONCOMPARER_H
+#pragma once
 
-
+#include "pch.h"
 
 class VersionComparer {
 public:
-    static bool isVersionNewer(const char* versionString, int major, int minor, int patch);
-
+    static bool is_version_newer(const char* versionString, int major, int minor, int patch);
 };
-
-
-
-#endif //VERSIONCOMPARER_H

--- a/gamebridge_reshade/src/configManager.cpp
+++ b/gamebridge_reshade/src/configManager.cpp
@@ -18,7 +18,7 @@ void ConfigManager::reload_config() {
         registered_config_values.push_back(ConfigManager::read_from_config(
                 "disable_3d_when_no_user_present"));
         registered_config_values.push_back(ConfigManager::read_from_config(
-                "disable_3d_when_no_user_present_grace_duration_in_seconds"));
+                "disable_3d_when_no_user_present_additional_grace_duration_in_ms"));
     } catch (std::runtime_error &e) {
         // Couldn't find the config values, let's write the defaults in the .ini
         std::string error_msg = "Unable to find config value in ReShade.ini: Now writing/loading defaults...";
@@ -40,9 +40,9 @@ void ConfigManager::write_missing_config_values() {
         reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present", "false");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_grace_duration", nullptr, &value_size);
+    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_additional_grace_duration_in_ms", nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_grace_duration_in_seconds", "3");
+        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_additional_grace_duration_in_ms", "0");
     }
 }
 
@@ -98,7 +98,7 @@ ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &ke
 void ConfigManager::load_default_config() {
     registered_config_values.erase(registered_config_values.begin(), registered_config_values.end());
     registered_config_values.push_back(ConfigValue("disable_3d_when_no_user_present", false));
-    registered_config_values.push_back(ConfigValue("disable_3d_when_no_user_present_grace_duration", 3));
+    registered_config_values.push_back(ConfigValue("disable_3d_when_no_user_present_additional_grace_duration_in_ms", 0));
 }
 
 bool ConfigManager::write_config_value(ConfigManager::ConfigValue value) {

--- a/gamebridge_reshade/src/configManager.cpp
+++ b/gamebridge_reshade/src/configManager.cpp
@@ -10,15 +10,16 @@
 #include <vector>
 #include <reshade/include/reshade.hpp>
 
-#include "ConfigManager.h"
+#include "configManager.h"
+#include "gbConstants.h"
 
 void ConfigManager::reload_config() {
     try {
         // Attempt to read config values from ReShade.ini
         registered_config_values.push_back(ConfigManager::read_from_config(
-                "disable_3d_when_no_user_present"));
+                gb_config_disable_3d_when_no_user));
         registered_config_values.push_back(ConfigManager::read_from_config(
-                "disable_3d_when_no_user_present_additional_grace_duration_in_ms"));
+                gb_config_disable_3d_when_no_user_grace_duration));
     } catch (std::runtime_error &e) {
         // Couldn't find the config values, let's write the defaults in the .ini
         std::string error_msg = "Unable to find config value in ReShade.ini: Now writing/loading defaults...";
@@ -35,14 +36,14 @@ ConfigManager::ConfigManager() {
 
 void ConfigManager::write_missing_config_values() {
     size_t value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_disable_3d_when_no_user.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present", "false");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_disable_3d_when_no_user.c_str(), "false");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_additional_grace_duration_in_ms", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_disable_3d_when_no_user_grace_duration.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_additional_grace_duration_in_ms", "0");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_disable_3d_when_no_user_grace_duration.c_str(), "0");
     }
 }
 
@@ -53,12 +54,12 @@ void remove_unwanted_nulls(std::vector<char>& vec) {
 
 ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &key) {
     size_t value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), key.c_str(), nullptr, &value_size);
     if (value_size > 0) {
         try {
             // Get the value from the config
             std::vector<char> value(value_size);
-            reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
+            reshade::get_config_value(nullptr, gb_config_section_name.c_str(), key.c_str(), value.data(), &value_size);
             // Remove unwanted '\0' characters as they confuse the string conversion.
             remove_unwanted_nulls(value);
             // Convert read value to lower case string
@@ -97,21 +98,21 @@ ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &ke
 
 void ConfigManager::load_default_config() {
     registered_config_values.erase(registered_config_values.begin(), registered_config_values.end());
-    registered_config_values.push_back(ConfigValue("disable_3d_when_no_user_present", false));
-    registered_config_values.push_back(ConfigValue("disable_3d_when_no_user_present_additional_grace_duration_in_ms", 0));
+    registered_config_values.push_back(ConfigValue(gb_config_disable_3d_when_no_user, false));
+    registered_config_values.push_back(ConfigValue(gb_config_disable_3d_when_no_user_grace_duration, 0));
 }
 
 bool ConfigManager::write_config_value(ConfigManager::ConfigValue value) {
     try {
         switch (value.value_type) {
             case ConfigValue::Type::String:
-                reshade::set_config_value(nullptr, "3DGameBridge", value.key.c_str(), value.string_value.c_str());
+                reshade::set_config_value(nullptr, gb_config_section_name.c_str(), value.key.c_str(), value.string_value.c_str());
                 break;
             case ConfigValue::Type::Bool:
-                reshade::set_config_value(nullptr, "3DGameBridge", value.key.c_str(), (value.bool_value) ? "true" : "false");
+                reshade::set_config_value(nullptr, gb_config_section_name.c_str(), value.key.c_str(), (value.bool_value) ? "true" : "false");
                 break;
             case ConfigValue::Type::Int:
-                reshade::set_config_value(nullptr, "3DGameBridge", value.key.c_str(), std::to_string(value.int_value).c_str());
+                reshade::set_config_value(nullptr, gb_config_section_name.c_str(), value.key.c_str(), std::to_string(value.int_value).c_str());
                 break;
             default:
                 break;

--- a/gamebridge_reshade/src/configManager.cpp
+++ b/gamebridge_reshade/src/configManager.cpp
@@ -14,12 +14,13 @@
 
 void ConfigManager::reload_config() {
     try {
+        // Attempt to read config values from ReShade.ini
         registered_config_values.push_back(ConfigManager::read_from_config(
                 "disable_3d_when_no_user_present"));
         registered_config_values.push_back(ConfigManager::read_from_config(
                 "disable_3d_when_no_user_present_grace_duration_in_seconds"));
     } catch (std::runtime_error &e) {
-        // Couldn't find the config value, let's write the default in the .ini
+        // Couldn't find the config values, let's write the defaults in the .ini
         std::string error_msg = "Unable to find config value in ReShade.ini: Now writing/loading defaults...";
         reshade::log_message(reshade::log_level::warning, error_msg.c_str());
         write_missing_config_values();
@@ -45,7 +46,7 @@ void ConfigManager::write_missing_config_values() {
     }
 }
 
-void removeUnwantedNulls(std::vector<char>& vec) {
+void remove_unwanted_nulls(std::vector<char>& vec) {
     // Find the first occurrence of '\0'
     vec.erase(std::remove(vec.begin(), vec.end(), '\0'), vec.end());
 }
@@ -59,7 +60,7 @@ ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &ke
             std::vector<char> value(value_size);
             reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
             // Remove unwanted '\0' characters as they confuse the string conversion.
-            removeUnwantedNulls(value);
+            remove_unwanted_nulls(value);
             // Convert read value to lower case string
             std::transform(value.begin(), value.end(), value.begin(),
                            [](unsigned char c){ return std::tolower(c); });

--- a/gamebridge_reshade/src/configManager.cpp
+++ b/gamebridge_reshade/src/configManager.cpp
@@ -1,0 +1,105 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+#include <reshade/include/reshade.hpp>
+
+#include "ConfigManager.h"
+
+ConfigManager::ConfigManager() {
+    // Todo: Check if we can read the config values we expect. Otherwise write defaults.
+    ConfigValue disable_3d_when_no_user_present = ConfigManager::read_from_config("disable_3d_when_no_user_present");
+    ConfigValue disable_3d_when_no_user_present_grace_duration = ConfigManager::read_from_config("disable_3d_when_no_user_present_grace_duration");
+    if (disable_3d_when_no_user_present.value_type == ConfigValue::Type::None || disable_3d_when_no_user_present_grace_duration.value_type == ConfigValue::Type::None) {
+        write_missing_config_values();
+    }
+}
+
+void ConfigManager::write_missing_config_values() {
+    size_t value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present", "false");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_grace_duration", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "disable_3d_when_no_user_present_grace_duration_in_seconds", 3);
+    }
+}
+
+void removeUnwantedNulls(std::vector<char>& vec) {
+    // Find the first occurrence of '\0'
+    auto firstNullIt = std::find(vec.begin(), vec.end(), '\0');
+
+    if (firstNullIt != vec.end()) {
+        // Check if the vector ends with only '\0' characters
+        if (std::all_of(firstNullIt, vec.end(), [](char c) { return c == '\0'; })) {
+            // The vector ends with only '\0', so preserve it as is
+            return;
+        }
+        // Otherwise, erase everything before the first group of '\0'
+        vec.erase(vec.begin(), firstNullIt + 1);
+    }
+}
+
+ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &key) {
+    size_t value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), nullptr, &value_size);
+    if (value_size > 0) {
+        try {
+            // Get the value from the config
+            std::vector<char> value(value_size);
+            reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
+            // Remove unwanted '\0' characters as they confuse the string conversion.
+            removeUnwantedNulls(value);
+            // Convert read value to lower case string
+            std::transform(value.begin(), value.end(), value.begin(),
+                           [](unsigned char c){ return std::tolower(c); });
+            std::string str(value.begin(), value.end());
+            // Try parsing as boolean
+            if (str == "true") {
+                return ConfigValue(true);
+            }
+            if (str == "false") {
+                return ConfigValue(false);
+            }
+
+            // Try parsing as integer
+            size_t idx = 0;
+            int int_value = std::stoi(str, &idx);
+            if (idx == str.length()) { // Entire string was a valid integer
+                return ConfigValue(int_value);
+            }
+
+            return ConfigValue(str);
+
+        }
+        catch (...)
+        {
+            std::string error_msg = "Unable to read hotkey from config file for config value: ";
+            error_msg += key;
+            error_msg += ". Please read the addon documentation to find out what values are valid.";
+            reshade::log_message(reshade::log_level::error, error_msg.c_str());
+        }
+        return ConfigValue();
+    }
+    throw std::runtime_error("Unable to read key from config");
+}
+
+void ConfigManager::load_default_config() {
+    registered_config_values.erase(registered_config_values.begin(), registered_config_values.end());
+    registered_config_values.push_back(ConfigValue());
+    registered_hot_keys.erase(registered_hot_keys.begin(), registered_hot_keys.end());
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true));
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true));
+}

--- a/gamebridge_reshade/src/configManager.h
+++ b/gamebridge_reshade/src/configManager.h
@@ -5,8 +5,8 @@
  * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
  */
 
-#ifndef CONFIGMANAGER_H
-#define CONFIGMANAGER_H
+#pragma once
+
 #include <string>
 
 class ConfigManager {
@@ -50,7 +50,3 @@ public:
 
     void reload_config();
 };
-
-
-
-#endif //CONFIGMANAGER_H

--- a/gamebridge_reshade/src/configManager.h
+++ b/gamebridge_reshade/src/configManager.h
@@ -20,7 +20,7 @@ public:
         bool bool_value;
 
         ConfigValue(std::string key, int intValue) : key(key), value_type(Type::Int), int_value(intValue) {}
-        ConfigValue(std::string key, const std::string& stringValue) : key(key), value_type(Type::String), string_value(stringValue) {}
+        ConfigValue(std::string key, std::string stringValue) : key(key), value_type(Type::String), string_value(std::move(stringValue)) {}
         ConfigValue(std::string key, bool boolValue) : key(key), value_type(Type::Bool), bool_value(boolValue) {}
         ConfigValue() : value_type(Type::None) {}
     };
@@ -44,7 +44,11 @@ public:
     // Returns an instance of the hotkey class based on the read config values.
     static ConfigValue read_from_config(const std::string& key);
 
+    static bool write_config_value(ConfigValue value);
+
     void load_default_config();
+
+    void reload_config();
 };
 
 

--- a/gamebridge_reshade/src/configManager.h
+++ b/gamebridge_reshade/src/configManager.h
@@ -1,0 +1,52 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#ifndef CONFIGMANAGER_H
+#define CONFIGMANAGER_H
+#include <string>
+
+class ConfigManager {
+public:
+    class ConfigValue {
+    public:
+        std::string key;
+        enum class Type { None, Int, String, Bool } value_type = Type::None;
+        std::string string_value;
+        int int_value;
+        bool bool_value;
+
+        ConfigValue(std::string key, int intValue) : key(key), value_type(Type::Int), int_value(intValue) {}
+        ConfigValue(std::string key, const std::string& stringValue) : key(key), value_type(Type::String), string_value(stringValue) {}
+        ConfigValue(std::string key, bool boolValue) : key(key), value_type(Type::Bool), bool_value(boolValue) {}
+        ConfigValue() : value_type(Type::None) {}
+    };
+
+    std::vector<ConfigValue> registered_config_values;
+
+    ConfigManager();
+
+    static void write_missing_config_values();
+
+    // Keys are stored in the config like so:
+    // [3DGameBridge]
+    // toggle_sr_key=0x31;shift;alt;ctrl
+    // toggle_sr_key=0x31;ctrl
+    // toggle_sr_key=0x31;
+    // toggle_sr_key=0x31
+    //
+    // The following keys are available: toggle_sr_key, toggle_lens_key, toggle_3d_key, toggle_lens_and_3d_key, toggle_latency_mode_key
+    //
+    // Method to read a specific key from the ReShade config.
+    // Returns an instance of the hotkey class based on the read config values.
+    static ConfigValue read_from_config(const std::string& key);
+
+    void load_default_config();
+};
+
+
+
+#endif //CONFIGMANAGER_H

--- a/gamebridge_reshade/src/delayLoader.h
+++ b/gamebridge_reshade/src/delayLoader.h
@@ -39,9 +39,7 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli) {
                     const DWORD errorCode = GetLastError();
                     if (errorCode == ERROR_MOD_NOT_FOUND) {
                         std::cout << "Module not found (ERROR_MOD_NOT_FOUND)" << std::endl;
-                        std::string error_msg = "Module could not be loaded: " + requested_dll;
-                        reshade::log_message(reshade::log_level::error, error_msg.c_str());
-                        return 0;
+                        return nullptr;
                     }
                     if (hModule) {
                         return reinterpret_cast<FARPROC>(hModule);

--- a/gamebridge_reshade/src/delayLoader.h
+++ b/gamebridge_reshade/src/delayLoader.h
@@ -10,7 +10,7 @@
 #include <Windows.h>
 #include <delayimp.h>
 
-std::array<std::string, 12> sr_dll_names = {"Glog.dll", "Opencv_world343.dll", "DimencoWeaving.dll", "SimulatedRealityCore.dll", "SimulatedRealityDisplays.dll", "SimulatedRealityFacetrackers.dll", "SimulatedRealityDirectX.dll", "DimencoWeaving32.dll", "SimulatedRealityCore32.dll", "SimulatedRealityDisplays32.dll", "SimulatedRealityFacetrackers32.dll", "SimulatedRealityDirectX32.dll"};
+std::array<std::string, 14> sr_dll_names = {"simulatedreality.dll", "simulatedreality32.dll", "Glog.dll", "Opencv_world343.dll", "DimencoWeaving.dll", "SimulatedRealityCore.dll", "SimulatedRealityDisplays.dll", "SimulatedRealityFacetrackers.dll", "SimulatedRealityDirectX.dll", "DimencoWeaving32.dll", "SimulatedRealityCore32.dll", "SimulatedRealityDisplays32.dll", "SimulatedRealityFacetrackers32.dll", "SimulatedRealityDirectX32.dll"};
 
 FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli) {
     std::string requested_dll;
@@ -39,6 +39,8 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli) {
                     const DWORD errorCode = GetLastError();
                     if (errorCode == ERROR_MOD_NOT_FOUND) {
                         std::cout << "Module not found (ERROR_MOD_NOT_FOUND)" << std::endl;
+                        std::string error_msg = "Module could not be loaded: " + requested_dll;
+                        reshade::log_message(reshade::log_level::error, error_msg.c_str());
                         return 0;
                     }
                     if (hModule) {

--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -10,6 +10,8 @@
 // Directx
 #include <DirectXMath.h>
 
+#include "configManager.h"
+
 DirectX10Weaver::DirectX10Weaver(SR::SRContext* context) {
     // Set context here.
     sr_context = context;
@@ -58,6 +60,7 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         return SUCCESS;
     }
 
+    DirectX10Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d10_device->get_resource_desc(rtv);
@@ -75,14 +78,15 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
 
         // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(default_weaver_latency);
-        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(default_weaver_latency) + " Microseconds";
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
         reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
             return DLL_NOT_LOADED;
         }
+        return GENERAL_FAIL;
     }
     catch (std::exception &e) {
         reshade::log_message(reshade::log_level::info, e.what());
@@ -95,25 +99,6 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
 
     weaver_initialized = true;
     return SUCCESS;
-}
-
-void DirectX10Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime) {
-    // Log activity status
-    ImGui::TextUnformatted("Status: ACTIVE");
-
-    // Log the latency mode
-    std::string latencyModeDisplay = "Latency mode: ";
-    if (current_latency_mode == LatencyModes::FRAMERATE_ADAPTIVE) {
-        latencyModeDisplay += "IN " + std::to_string(last_latency_frame_time_set) + " MICROSECONDS";
-    }
-    else {
-        latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
-    }
-    ImGui::TextUnformatted(latencyModeDisplay.c_str());
-
-    // Log the buffer type, this can be removed once we've tested a larger amount of games.
-    std::string s = "Buffer type: " + std::to_string(static_cast<uint32_t>(current_buffer_format));
-    ImGui::TextUnformatted(s.c_str());
 }
 
 GbResult DirectX10Weaver::on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view rtv_srgb) {
@@ -222,7 +207,7 @@ bool DirectX10Weaver::set_latency_frametime_adaptive(uint32_t frametime_in_micro
     if (weaver_initialized) {
         set_latency_mode(LatencyModes::FRAMERATE_ADAPTIVE);
         weaver->setLatency(frametime_in_microseconds);
-        last_latency_frame_time_set = frametime_in_microseconds;
+        weaver_latency_in_us = frametime_in_microseconds;
         return true;
     }
     return false;

--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -89,7 +89,7 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
     weaver_initialized = true;
 
     // Determine the default latency mode for the weaver
-    DirectX10Weaver::determine_default_latency_mode();
+    determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -7,11 +7,6 @@
 
 #include "directx10weaver.h"
 
-// Directx
-#include <DirectXMath.h>
-
-#include "configManager.h"
-
 DirectX10Weaver::DirectX10Weaver(SR::SRContext* context) {
     // Set context here.
     sr_context = context;
@@ -76,11 +71,6 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         weaver->setInputFrameBuffer((ID3D10ShaderResourceView*)rtv.handle); // Resourceview of the buffer
         sr_context->initialize();
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
-
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-        reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
@@ -98,6 +88,21 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
     }
 
     weaver_initialized = true;
+
+    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
+    std::string latency_log;
+
+    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
+        set_latency_in_frames(-1);
+        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
+    } else {
+        // Set mode to latency in frames by default.
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
+    }
+
+    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+
     return SUCCESS;
 }
 

--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -88,19 +88,8 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
 
     weaver_initialized = true;
 
-    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
-    std::string latency_log;
-
-    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
-        set_latency_in_frames(-1);
-        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
-    } else {
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-    }
-
-    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+    // Determine the default latency mode for the weaver
+    DirectX10Weaver::determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx10weaver.cpp
+++ b/gamebridge_reshade/src/directx10weaver.cpp
@@ -55,7 +55,6 @@ GbResult DirectX10Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         return SUCCESS;
     }
 
-    DirectX10Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d10_device->get_resource_desc(rtv);

--- a/gamebridge_reshade/src/directx10weaver.h
+++ b/gamebridge_reshade/src/directx10weaver.h
@@ -14,7 +14,6 @@
 #include "pch.h"
 
 class DirectX10Weaver: public IGraphicsApi {
-    uint32_t last_latency_frame_time_set = default_weaver_latency;
     uint32_t effect_frame_copy_x = 0, effect_frame_copy_y = 0;
 
     bool weaver_initialized = false;
@@ -30,7 +29,6 @@ class DirectX10Weaver: public IGraphicsApi {
     SR::PredictingDX10Weaver* weaver = nullptr;
 
     reshade::api::device* d3d10_device = nullptr;
-    reshade::api::format current_buffer_format = reshade::api::format::unknown;
     reshade::api::command_list* command_list{};
     reshade::api::resource effect_frame_copy{};
     reshade::api::resource_view effect_frame_copy_srv{};
@@ -64,7 +62,6 @@ public:
 
 
     // Inherited via IGraphicsApi
-    void draw_status_overlay(reshade::api::effect_runtime *runtime) override;
     GbResult on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view rtv_srgb) override;
     void on_init_effect_runtime(reshade::api::effect_runtime* runtime) override;
     void do_weave(bool do_weave) override;

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -64,6 +64,7 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
         return SUCCESS;
     }
 
+    DirectX11Weaver::user_presence_3d_toggle_checked = false;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d11_device->get_resource_desc(rtv);
@@ -86,20 +87,6 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
         weaver->setInputFrameBuffer((ID3D11ShaderResourceView*)rtv.handle); // Resourceview of the buffer
         sr_context->initialize();
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
-
-        // Todo: Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
-        std::string latency_log;
-
-        if (VersionComparer::isVersionNewer(getSRPlatformVersion(), 1, 30, 0)) {
-            set_latency_in_frames(-1);
-            latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
-        } else {
-            // Set mode to latency in frames by default.
-            set_latency_frametime_adaptive(default_weaver_latency);
-            latency_log = "Current latency mode set to: STATIC " + std::to_string(default_weaver_latency) + " Microseconds";
-        }
-
-        reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
@@ -116,23 +103,38 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
     }
 
     weaver_initialized = true;
+
+    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
+    std::string latency_log;
+
+    if (VersionComparer::isVersionNewer(getSRPlatformVersion(), 1, 30, 0)) {
+        set_latency_in_frames(-1);
+        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
+    } else {
+        // Set mode to latency in frames by default.
+        set_latency_frametime_adaptive(default_weaver_latency);
+        latency_log = "Current latency mode set to: STATIC " + std::to_string(default_weaver_latency) + " Microseconds";
+    }
+
+    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+
     return SUCCESS;
 }
 
 void DirectX11Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime) {
-    // Todo: Check this every frame and update the logic based on its state, also write to config
-    bool user_presence_3d_toggle_checked = false;
-
     // Log activity status
     ImGui::TextUnformatted("Status: ACTIVE");
 
     // Log the latency mode
     std::string latencyModeDisplay = "Latency mode: ";
-    if (current_latency_mode == LatencyModes::FRAMERATE_ADAPTIVE) {
+    if (get_latency_mode() == LatencyModes::FRAMERATE_ADAPTIVE) {
         latencyModeDisplay += "IN " + std::to_string(last_latency_frame_time_set) + " MICROSECONDS";
     }
+    else if (get_latency_mode() == LatencyModes::LATENCY_IN_FRAMES) {
+        latencyModeDisplay += "IN 1 FRAME";
+    }
     else {
-        latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
+        latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAME(S)";
     }
     ImGui::TextUnformatted(latencyModeDisplay.c_str());
 
@@ -148,11 +150,14 @@ void DirectX11Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime)
         {
             reshade::log_message(reshade::log_level::info, "User based 3D checkbox enabled");
             // Add your code to handle when the checkbox is checked
+            // Todo: write to config
+            // Todo: Change presence logic bool
         }
         else
         {
             reshade::log_message(reshade::log_level::info, "User based 3D checkbox disabled");
             // Add your code to handle when the checkbox is unchecked
+            user_presence_3d_toggle_checked = false;
         }
     }
 }

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -96,19 +96,8 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
 
     weaver_initialized = true;
 
-    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
-    std::string latency_log;
-
-    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
-        set_latency_in_frames(-1);
-        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
-    } else {
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-    }
-
-    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+    // Determine the default latency mode for the weaver
+    DirectX11Weaver::determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -56,7 +56,6 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
         return SUCCESS;
     }
 
-    DirectX11Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d11_device->get_resource_desc(rtv);

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -7,15 +7,6 @@
 
 #include "directx11weaver.h"
 
-// Directx
-#include <DirectXMath.h>
-#include <sr/sense/system/systemsense.h>
-#include <sr/version_c.h>
-
-#include "configManager.h"
-#include "directx10weaver.h"
-#include "VersionComparer.h"
-
 DirectX11Weaver::DirectX11Weaver(SR::SRContext* context) {
     // Set context here.
     sr_context = context;

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -97,7 +97,7 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
     weaver_initialized = true;
 
     // Determine the default latency mode for the weaver
-    DirectX11Weaver::determine_default_latency_mode();
+    determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx11weaver.cpp
+++ b/gamebridge_reshade/src/directx11weaver.cpp
@@ -83,7 +83,6 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
     }
 
     try {
-        // Todo: Gets access violations when no SR screen is connected!
         weaver = new SR::PredictingDX11Weaver(*sr_context, dev, context, desc.texture.width, desc.texture.height, (HWND)runtime->get_hwnd());
         weaver->setContext((ID3D11DeviceContext*)cmd_list->get_native());
         weaver->setInputFrameBuffer((ID3D11ShaderResourceView*)rtv.handle); // Resourceview of the buffer
@@ -110,7 +109,7 @@ GbResult DirectX11Weaver::init_weaver(reshade::api::effect_runtime *runtime, res
     // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
     std::string latency_log;
 
-    if (VersionComparer::isVersionNewer(getSRPlatformVersion(), 1, 30, 0)) {
+    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
         set_latency_in_frames(-1);
         latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
     } else {

--- a/gamebridge_reshade/src/directx11weaver.h
+++ b/gamebridge_reshade/src/directx11weaver.h
@@ -14,7 +14,6 @@
 #include "pch.h"
 
 class DirectX11Weaver: public IGraphicsApi {
-    uint32_t last_latency_frame_time_set = default_weaver_latency;
     uint32_t effect_frame_copy_x = 0, effect_frame_copy_y = 0;
 
     bool weaver_initialized = false;
@@ -33,7 +32,6 @@ class DirectX11Weaver: public IGraphicsApi {
     reshade::api::command_list* command_list{};
     reshade::api::resource effect_frame_copy{};
     reshade::api::resource_view effect_frame_copy_srv{};
-    reshade::api::format current_buffer_format = reshade::api::format::unknown;
 
     LatencyModes current_latency_mode = LatencyModes::FRAMERATE_ADAPTIVE;
 
@@ -65,7 +63,6 @@ public:
 
 
     // Inherited via IGraphicsApi
-    void draw_status_overlay(reshade::api::effect_runtime *runtime) override;
     GbResult on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view rtv_srgb) override;
     void on_init_effect_runtime(reshade::api::effect_runtime* runtime) override;
     void do_weave(bool do_weave) override;

--- a/gamebridge_reshade/src/directx12weaver.cpp
+++ b/gamebridge_reshade/src/directx12weaver.cpp
@@ -70,7 +70,7 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
     weaver_initialized = true;
 
     // Determine the default latency mode for the weaver
-    DirectX12Weaver::determine_default_latency_mode();
+    determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx12weaver.cpp
+++ b/gamebridge_reshade/src/directx12weaver.cpp
@@ -10,6 +10,8 @@
 // Directx
 #include <DirectXMath.h>
 
+#include "configManager.h"
+
 DirectX12Weaver::DirectX12Weaver(SR::SRContext* context) {
     // Set context here.
     sr_context = context;
@@ -20,6 +22,8 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
     if (weaver_initialized) {
         return SUCCESS;
     }
+
+    DirectX12Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
 
     // See if we can get a command allocator from reshade
     ID3D12Device* dev = ((ID3D12Device*)d3d12_device->get_native());
@@ -56,14 +60,15 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
 
         // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(default_weaver_latency);
-        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(default_weaver_latency) + " Microseconds";
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
         reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
             return DLL_NOT_LOADED;
         }
+        return GENERAL_FAIL;
     }
     catch (std::exception& e) {
         reshade::log_message(reshade::log_level::info, e.what());
@@ -76,25 +81,6 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
 
     weaver_initialized = true;
     return SUCCESS;
-}
-
-void DirectX12Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime) {
-    // Log activity status
-    ImGui::TextUnformatted("Status: ACTIVE");
-
-    // Log the latency mode
-    std::string latency_mode_display = "Latency mode: ";
-    if (current_latency_mode == LatencyModes::FRAMERATE_ADAPTIVE) {
-        latency_mode_display += "IN " + std::to_string(last_latency_frame_time_set) + " MICROSECONDS";
-    }
-    else {
-        latency_mode_display += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
-    }
-    ImGui::TextUnformatted(latency_mode_display.c_str());
-
-    // Log the buffer type, this can be removed once we've tested a larger amount of games.
-    std::string s = "Buffer type: " + std::to_string(static_cast<uint32_t>(current_buffer_format));
-    ImGui::TextUnformatted(s.c_str());
 }
 
 bool DirectX12Weaver::create_effect_copy_buffer(const reshade::api::resource_desc& effect_resource_desc) {
@@ -256,7 +242,7 @@ bool DirectX12Weaver::set_latency_frametime_adaptive(uint32_t frametime_in_micro
     if (weaver_initialized) {
         set_latency_mode(LatencyModes::FRAMERATE_ADAPTIVE);
         weaver->setLatency(frametime_in_microseconds);
-        last_latency_frame_time_set = frametime_in_microseconds;
+        weaver_latency_in_us = frametime_in_microseconds;
         return true;
     }
     return false;

--- a/gamebridge_reshade/src/directx12weaver.cpp
+++ b/gamebridge_reshade/src/directx12weaver.cpp
@@ -69,19 +69,8 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
 
     weaver_initialized = true;
 
-    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
-    std::string latency_log;
-
-    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
-        set_latency_in_frames(-1);
-        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
-    } else {
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-    }
-
-    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+    // Determine the default latency mode for the weaver
+    DirectX12Weaver::determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx12weaver.cpp
+++ b/gamebridge_reshade/src/directx12weaver.cpp
@@ -18,8 +18,6 @@ GbResult DirectX12Weaver::init_weaver(reshade::api::effect_runtime* runtime, res
         return SUCCESS;
     }
 
-    DirectX12Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
-
     // See if we can get a command allocator from reshade
     ID3D12Device* dev = ((ID3D12Device*)d3d12_device->get_native());
     if (!dev) {

--- a/gamebridge_reshade/src/directx12weaver.h
+++ b/gamebridge_reshade/src/directx12weaver.h
@@ -14,7 +14,6 @@
 #include "pch.h"
 
 class DirectX12Weaver: public IGraphicsApi {
-    uint32_t last_latency_frame_time_set = default_weaver_latency;
     uint32_t effect_frame_copy_x = 0, effect_frame_copy_y = 0;
 
     bool weaver_initialized = false;
@@ -33,7 +32,6 @@ class DirectX12Weaver: public IGraphicsApi {
     reshade::api::command_list* command_list{};
     reshade::api::resource effect_frame_copy{};
     reshade::api::resource_view game_frame_buffer{};
-    reshade::api::format current_buffer_format = reshade::api::format::unknown;
 
     LatencyModes current_latency_mode = LatencyModes::FRAMERATE_ADAPTIVE;
 
@@ -63,7 +61,6 @@ public:
     bool create_effect_copy_buffer(const reshade::api::resource_desc& effect_resource_desc);
 
     // Inherited via IGraphicsApi
-    void draw_status_overlay(reshade::api::effect_runtime *runtime) override;
     GbResult on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view) override;
     void on_init_effect_runtime(reshade::api::effect_runtime* runtime) override;
     void do_weave(bool do_weave) override;

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -81,19 +81,8 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
 
     weaver_initialized = true;
 
-    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
-    std::string latency_log;
-
-    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
-        set_latency_in_frames(-1);
-        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
-    } else {
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-    }
-
-    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+    // Determine the default latency mode for the weaver
+    DirectX9Weaver::determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -64,11 +64,6 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
         weaver->setInputFrameBuffer((IDirect3DTexture9*)rtv.handle); // Resourceview of the buffer
         sr_context->initialize();
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
-
-        // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(weaver_latency_in_us);
-        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
-        reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
@@ -86,6 +81,21 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
     }
 
     weaver_initialized = true;
+
+    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
+    std::string latency_log;
+
+    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
+        set_latency_in_frames(-1);
+        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
+    } else {
+        // Set mode to latency in frames by default.
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
+    }
+
+    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+
     return SUCCESS;
 }
 

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -10,6 +10,8 @@
 // Directx
 #include <DirectXMath.h>
 
+#include "configManager.h"
+
 DirectX9Weaver::DirectX9Weaver(SR::SRContext* context) {
     // Set context here.
     sr_context = context;
@@ -46,6 +48,7 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
         return SUCCESS;
     }
 
+    DirectX9Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d9_device->get_resource_desc(rtv);
@@ -63,14 +66,15 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
         reshade::log_message(reshade::log_level::info, "Initialized weaver");
 
         // Set mode to latency in frames by default.
-        set_latency_frametime_adaptive(default_weaver_latency);
-        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(default_weaver_latency) + " Microseconds";
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        std::string latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
         reshade::log_message(reshade::log_level::info, latency_log.c_str());
     }
     catch (std::runtime_error &e) {
         if (std::strcmp(e.what(), "Failed to load library") == 0) {
             return DLL_NOT_LOADED;
         }
+        return GENERAL_FAIL;
     }
     catch (std::exception &e) {
         reshade::log_message(reshade::log_level::info, e.what());
@@ -83,25 +87,6 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
 
     weaver_initialized = true;
     return SUCCESS;
-}
-
-void DirectX9Weaver::draw_status_overlay(reshade::api::effect_runtime *runtime) {
-    // Log activity status
-    ImGui::TextUnformatted("Status: ACTIVE");
-
-    // Log the latency mode
-    std::string latencyModeDisplay = "Latency mode: ";
-    if (current_latency_mode == LatencyModes::FRAMERATE_ADAPTIVE) {
-        latencyModeDisplay += "IN " + std::to_string(last_latency_frame_time_set) + " MICROSECONDS";
-    }
-    else {
-        latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAMES";
-    }
-    ImGui::TextUnformatted(latencyModeDisplay.c_str());
-
-    // Log the buffer type, this can be removed once we've tested a larger amount of games.
-    std::string s = "Buffer type: " + std::to_string(static_cast<uint32_t>(current_buffer_format));
-    ImGui::TextUnformatted(s.c_str());
 }
 
 GbResult DirectX9Weaver::on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view rtv_srgb) {
@@ -216,7 +201,7 @@ bool DirectX9Weaver::set_latency_frametime_adaptive(uint32_t frametime_in_micros
     if (weaver_initialized) {
         set_latency_mode(LatencyModes::FRAMERATE_ADAPTIVE);
         weaver->setLatency(frametime_in_microseconds);
-        last_latency_frame_time_set = frametime_in_microseconds;
+        weaver_latency_in_us = frametime_in_microseconds;
         return true;
     }
     return false;

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -48,7 +48,6 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
         return SUCCESS;
     }
 
-    DirectX9Weaver::user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
     delete weaver;
     weaver = nullptr;
     reshade::api::resource_desc desc = d3d9_device->get_resource_desc(rtv);

--- a/gamebridge_reshade/src/directx9weaver.cpp
+++ b/gamebridge_reshade/src/directx9weaver.cpp
@@ -82,7 +82,7 @@ GbResult DirectX9Weaver::init_weaver(reshade::api::effect_runtime* runtime, resh
     weaver_initialized = true;
 
     // Determine the default latency mode for the weaver
-    DirectX9Weaver::determine_default_latency_mode();
+    determine_default_latency_mode();
 
     return SUCCESS;
 }

--- a/gamebridge_reshade/src/directx9weaver.h
+++ b/gamebridge_reshade/src/directx9weaver.h
@@ -14,7 +14,6 @@
 #include "pch.h"
 
 class DirectX9Weaver: public IGraphicsApi {
-    uint32_t last_latency_frame_time_set = default_weaver_latency;
     uint32_t effect_frame_copy_x = 0, effect_frame_copy_y = 0;
 
     bool weaver_initialized = false;
@@ -31,7 +30,6 @@ class DirectX9Weaver: public IGraphicsApi {
 
     reshade::api::device* d3d9_device = nullptr;
 
-    reshade::api::format current_buffer_format = reshade::api::format::unknown;
     reshade::api::command_list* command_list{};
     reshade::api::resource effect_frame_copy{};
 
@@ -63,7 +61,6 @@ public:
     bool create_effect_copy_buffer(const reshade::api::resource_desc& effect_resource_desc);
 
     // Inherited via IGraphicsApi
-    void draw_status_overlay(reshade::api::effect_runtime *runtime) override;
     GbResult on_reshade_finish_effects(reshade::api::effect_runtime* runtime, reshade::api::command_list* cmd_list, reshade::api::resource_view rtv, reshade::api::resource_view rtv_srgb) override;
     void on_init_effect_runtime(reshade::api::effect_runtime* runtime) override;
     void do_weave(bool do_weave) override;

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -156,7 +156,7 @@ static void execute_hot_key_function_by_type(std::map<shortcutType, bool> hot_ke
             }
             break;
         case shortcutType::TOGGLE_LENS_AND_3D:
-            // Todo: This should look at the current state of the lens toggle and 3D toggle, then, flip those.This toggle having its own state isn't great.
+            // This looks at the current state of the lens and toggles it.
             if (lens_hint != nullptr && lens_hint->isEnabled()) {
                 toggle_map = {{shortcutType::TOGGLE_LENS, false}, {shortcutType::TOGGLE_3D, false} };
             }
@@ -238,20 +238,19 @@ static void on_reshade_finish_effects(reshade::api::effect_runtime* runtime, res
 
     // Check if user is still within view of the camera
     user_lost_logic_enabled = weaver_implementation->user_presence_3d_toggle_checked;
-    if (user_lost_logic_enabled){
+    if (user_lost_logic_enabled) {
         if (sense_listener.isUserLost) {
             if (!user_lost_grace_period_active) {
                 // Start the grace period timer
                 user_lost_timestamp = chrono::high_resolution_clock::now();
             }
             user_lost_grace_period_active = true;
-            // Todo: Make this timeout value configurable in config.ini
+            // Compare current timeout with grace period from config file
             if (std::chrono::duration_cast<std::chrono::seconds>(chrono::high_resolution_clock::now() - user_lost_timestamp) > std::chrono::seconds(user_lost_grace_period_duration_in_seconds)) {
                 // Skip the weaving step by returning here
                 return;
             }
         } else {
-            // Todo: Do we have a way to not do this every frame?
             user_lost_grace_period_active = false;
         }
     }
@@ -304,7 +303,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
         return;
     }
 
-    // Move these hard-coded hotkeys to user-definable hotkeys in the .ini file
+    // These hotkeys are reconfigurable from the ReShade.ini file
     // Register some standard hotkeys
     if (hotKey_manager == nullptr) {
         hotKey_manager = new HotKeyManager();

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -266,7 +266,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     // Todo: Move these hard-coded hotkeys to user-definable hotkeys in the .ini file
     // Register some standard hotkeys
     if (hotKey_manager == nullptr) {
-        hotKey_manager = new HotKeyManager(runtime);
+        hotKey_manager = new HotKeyManager();
     }
 
     try {

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -235,7 +235,7 @@ static void on_reshade_finish_effects(reshade::api::effect_runtime* runtime, res
     // }
 
     // Check if user is still within view of the camera
-    user_lost_logic_enabled = weaver_implementation->user_presence_3d_toggle_checked;
+    user_lost_logic_enabled = weaver_implementation->is_user_presence_3d_toggle_checked();
     if (user_lost_logic_enabled) {
         if (sense_listener.isUserLost) {
             if (!user_lost_grace_period_active) {

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -266,7 +266,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     // Todo: Move these hard-coded hotkeys to user-definable hotkeys in the .ini file
     // Register some standard hotkeys
     if (hotKey_manager == nullptr) {
-        hotKey_manager = new HotKeyManager();
+        hotKey_manager = new HotKeyManager(runtime);
     }
 
     try {

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -49,9 +49,8 @@ static char char_buffer[CHAR_BUFFER_SIZE];
 static size_t char_buffer_size = CHAR_BUFFER_SIZE;
 static bool sr_initialized = false;
 static bool user_lost_grace_period_active = false;
-// Todo: Read initial value from config
 static bool user_lost_logic_enabled = false;
-static int user_lost_grace_period_duration_in_seconds = 3;
+static int user_lost_additional_grace_period_duration_in_ms = 0;
 static chrono::steady_clock::time_point user_lost_timestamp;
 
 std::vector<LPCWSTR> reshade_dll_names =  { L"dxgi.dll", L"ReShade.dll", L"ReShade64.dll", L"ReShade32.dll", L"d3d9.dll", L"d3d10.dll", L"d3d11.dll", L"d3d12.dll", L"opengl32.dll" };
@@ -246,7 +245,7 @@ static void on_reshade_finish_effects(reshade::api::effect_runtime* runtime, res
             }
             user_lost_grace_period_active = true;
             // Compare current timeout with grace period from config file
-            if (std::chrono::duration_cast<std::chrono::seconds>(chrono::high_resolution_clock::now() - user_lost_timestamp) > std::chrono::seconds(user_lost_grace_period_duration_in_seconds)) {
+            if (std::chrono::duration_cast<std::chrono::milliseconds>(chrono::high_resolution_clock::now() - user_lost_timestamp) > std::chrono::milliseconds(user_lost_additional_grace_period_duration_in_ms)) {
                 // Skip the weaving step by returning here
                 return;
             }
@@ -315,8 +314,8 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
             if (config_manager->registered_config_values[i].key == "disable_3d_when_no_user_present") {
                 user_lost_logic_enabled = config_manager->registered_config_values[i].bool_value;
             }
-            if (config_manager->registered_config_values[i].key == "disable_3d_when_no_user_present_grace_duration_in_seconds") {
-                user_lost_grace_period_duration_in_seconds = config_manager->registered_config_values[i].int_value;
+            if (config_manager->registered_config_values[i].key == "disable_3d_when_no_user_present_additional_grace_duration_in_ms") {
+                user_lost_additional_grace_period_duration_in_ms = config_manager->registered_config_values[i].int_value;
             }
         }
     }

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -176,7 +176,7 @@ static void execute_hot_key_function_by_type(std::map<shortcutType, bool> hot_ke
             }
             else {
                 // Set the latency to the SR default of 40000 microseconds (Tuned for 60Hz)
-                weaver_implementation->set_latency_frametime_adaptive(default_weaver_latency);
+                weaver_implementation->set_latency_frametime_adaptive(weaver_implementation->weaver_latency_in_us);
 
                 // Log the current mode:
                 reshade::log_message(reshade::log_level::info, "Current latency mode set to: STATIC 40000 Microseconds");

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -229,11 +229,10 @@ static void on_reshade_finish_effects(reshade::api::effect_runtime* runtime, res
     }
 
     // Check if certain hotkeys are being pressed
-    if (config_manager != nullptr) {
+    // if (config_manager != nullptr) {
         // Todo: Update the state of the config based on if the user changed the setting in the UI
         // write_config_value();
-        // Todo: Update the bool that sets whether to do the userlost logic
-    }
+    // }
 
     // Check if user is still within view of the camera
     user_lost_logic_enabled = weaver_implementation->user_presence_3d_toggle_checked;

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -49,6 +49,7 @@ static char char_buffer[CHAR_BUFFER_SIZE];
 static size_t char_buffer_size = CHAR_BUFFER_SIZE;
 static bool sr_initialized = false;
 static bool user_lost_grace_period_active = false;
+// Todo: Read initial value from config
 static bool user_lost_logic_enabled = false;
 static int user_lost_grace_period_duration_in_seconds = 3;
 static chrono::steady_clock::time_point user_lost_timestamp;
@@ -236,6 +237,7 @@ static void on_reshade_finish_effects(reshade::api::effect_runtime* runtime, res
     }
 
     // Check if user is still within view of the camera
+    user_lost_logic_enabled = weaver_implementation->user_presence_3d_toggle_checked;
     if (user_lost_logic_enabled){
         if (sense_listener.isUserLost) {
             if (!user_lost_grace_period_active) {

--- a/gamebridge_reshade/src/gbConstants.h
+++ b/gamebridge_reshade/src/gbConstants.h
@@ -1,0 +1,23 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#pragma once
+
+#include <string>
+
+const std::string gb_config_section_name = "3DGameBridge";
+const std::string gb_config_disable_3d_when_no_user = "disable_3d_when_no_user_present";
+const std::string gb_config_disable_3d_when_no_user_grace_duration = "disable_3d_when_no_user_present_additional_grace_duration_in_ms";
+const std::string gb_config_toggle_sr_key = "toggle_sr_key";
+const std::string gb_config_toggle_lens_key = "toggle_lens_key";
+const std::string gb_config_toggle_3d_key = "toggle_3d_key";
+const std::string gb_config_toggle_lens_and_3d_key = "toggle_lens_and_3d_key";
+const std::string gb_config_toggle_latency_mode_key = "toggle_latency_mode_key";
+
+const std::string gb_config_shift_mod = "shift";
+const std::string gb_config_alt_mod = "alt";
+const std::string gb_config_ctrl_mod = "ctrl";

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -28,7 +28,7 @@ private:
     static void write_missing_hotkeys();
 
     // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.
-    static void removeUnwantedNulls(std::vector<char>& vec);
+    static void remove_unwanted_nulls(std::vector<char>& vec);
 
     // Keys are stored in the config like so:
     // [3DGameBridge]

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -23,6 +23,8 @@ private:
     std::vector<HotKey> registered_hot_keys;
 
     // Writes hotkeys if they are not present in the ReShade.ini file
+    void load_default_hotkeys();
+
     static void write_missing_hotkeys();
 
     // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -14,7 +14,7 @@
 
 class HotKeyManager {
 public:
-    HotKeyManager();
+    explicit HotKeyManager(reshade::api::effect_runtime* runtime);
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
     // Todo: Implement a way to edit and create now hotkeys?
     void edit_hot_key(uint8_t hot_key_id);
@@ -22,4 +22,16 @@ public:
 private:
     // Todo: We should define these in a .ini file eventually.
     std::vector<HotKey> registered_hot_keys;
+
+    // Keys are stored in the config like so:
+    // [3DGameBridge]
+    // toggle_sr_key=0x31;shift;alt;ctrl
+    // toggle_sr_key=0x31;ctrl
+    // toggle_sr_key=0x31;
+    //
+    // The following keys are available: toggle_sr_key, toggle_lens_key, toggle_3d_key, toggle_lens_and_3d_key, toggle_latency_mode_key
+    //
+    // Method to read a specific key from the ReShade config.
+    // Returns an instance of the hotkey class based on the read config values.
+    HotKey read_from_config(bool default_enabled, std::string key, shortcutType shortcut);
 };

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -16,22 +16,25 @@ class HotKeyManager {
 public:
     explicit HotKeyManager(reshade::api::effect_runtime* runtime);
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
-    // Todo: Implement a way to edit and create now hotkeys?
+    // Todo: Implement a way to edit and create new hotkeys?
     void edit_hot_key(uint8_t hot_key_id);
 
 private:
-    // Todo: We should define these in a .ini file eventually.
     std::vector<HotKey> registered_hot_keys;
+
+    // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.
+    static void removeUnwantedNulls(std::vector<char>& vec);
 
     // Keys are stored in the config like so:
     // [3DGameBridge]
     // toggle_sr_key=0x31;shift;alt;ctrl
     // toggle_sr_key=0x31;ctrl
     // toggle_sr_key=0x31;
+    // toggle_sr_key=0x31
     //
     // The following keys are available: toggle_sr_key, toggle_lens_key, toggle_3d_key, toggle_lens_and_3d_key, toggle_latency_mode_key
     //
     // Method to read a specific key from the ReShade config.
     // Returns an instance of the hotkey class based on the read config values.
-    HotKey read_from_config(bool default_enabled, std::string key, shortcutType shortcut);
+    static HotKey read_from_config(bool default_enabled, const std::string& key, shortcutType shortcut);
 };

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -22,6 +22,9 @@ public:
 private:
     std::vector<HotKey> registered_hot_keys;
 
+    // Writes hotkeys if they are not present in the ReShade.ini file
+    static void write_missing_hotkeys();
+
     // Helper function to split off unwanted '\0' characters from vector arrays for easy processing.
     static void removeUnwantedNulls(std::vector<char>& vec);
 

--- a/gamebridge_reshade/src/hotkeyManager.h
+++ b/gamebridge_reshade/src/hotkeyManager.h
@@ -14,7 +14,7 @@
 
 class HotKeyManager {
 public:
-    explicit HotKeyManager(reshade::api::effect_runtime* runtime);
+    HotKeyManager();
     std::map<shortcutType, bool> check_hot_keys(reshade::api::effect_runtime* runtime, SR::SRContext* context);
     // Todo: Implement a way to edit and create new hotkeys?
     void edit_hot_key(uint8_t hot_key_id);

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -65,7 +65,7 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
     throw std::runtime_error("Unable to read key from config");
 }
 
-HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
+HotKeyManager::HotKeyManager() {
     // Create some default hotkeys.
     try {
         registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -72,7 +72,7 @@ HotKeyManager::HotKeyManager() {
         registered_hot_keys.push_back(read_from_config(true, "toggle_lens_key", TOGGLE_LENS));
         registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
         registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
-        registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+        registered_hot_keys.push_back(read_from_config(true, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
     }
     catch (std::runtime_error &e) {
         // Couldn't find the config value, let's write the default in the .ini

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "hotkeyManager.h"
+#include "gbConstants.h"
 
 void HotKeyManager::remove_unwanted_nulls(std::vector<char>& vec) {
     // Find the first occurrence of '\0'
@@ -24,13 +25,13 @@ void HotKeyManager::remove_unwanted_nulls(std::vector<char>& vec) {
 
 HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& key, shortcutType shortcut) {
     size_t value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), key.c_str(), nullptr, &value_size);
     if (value_size > 0) {
         HotKey created_key;
         try {
             // Get the value from the config
             std::vector<char> value(value_size);
-            reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
+            reshade::get_config_value(nullptr, gb_config_section_name.c_str(), key.c_str(), value.data(), &value_size);
             // Remove unwanted '\0' characters as they confuse the string conversion.
             remove_unwanted_nulls(value);
             // Convert read value to lower case string
@@ -51,7 +52,7 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
                 }
             }
             // Create the hotkey
-            created_key = HotKey(default_enabled, shortcut, found_key, str.find("shift") != std::string::npos, str.find("alt") != std::string::npos, str.find("ctrl") != std::string::npos);
+            created_key = HotKey(default_enabled, shortcut, found_key, str.find(gb_config_shift_mod.c_str()) != std::string::npos, str.find(gb_config_alt_mod.c_str()) != std::string::npos, str.find(gb_config_ctrl_mod.c_str()) != std::string::npos);
         }
         catch (...)
         {
@@ -68,11 +69,11 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
 HotKeyManager::HotKeyManager() {
     // Create some default hotkeys.
     try {
-        registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
-        registered_hot_keys.push_back(read_from_config(true, "toggle_lens_key", TOGGLE_LENS));
-        registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
-        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
-        registered_hot_keys.push_back(read_from_config(true, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+        registered_hot_keys.push_back(read_from_config(true, gb_config_toggle_sr_key, TOGGLE_SR));
+        registered_hot_keys.push_back(read_from_config(true, gb_config_toggle_lens_key, TOGGLE_LENS));
+        registered_hot_keys.push_back(read_from_config(false, gb_config_toggle_3d_key, TOGGLE_3D));
+        registered_hot_keys.push_back(read_from_config(false, gb_config_toggle_lens_and_3d_key, TOGGLE_LENS_AND_3D));
+        registered_hot_keys.push_back(read_from_config(true, gb_config_toggle_latency_mode_key, TOGGLE_LATENCY_MODE));
     }
     catch (std::runtime_error &e) {
         // Couldn't find the config value, let's write the default in the .ini
@@ -130,29 +131,29 @@ void HotKeyManager::edit_hot_key(uint8_t hot_key_id) {
 
 void HotKeyManager::write_missing_hotkeys() {
     size_t value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_sr_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_sr_key", "0x31\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_sr_key.c_str(), "0x31\;ctrl");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_key", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_key", "0x32\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_key.c_str(), "0x32\;ctrl");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_3d_key", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_3d_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_3d_key", "0x33\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_3d_key.c_str(), "0x33\;ctrl");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_and_3d_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", "0x34\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_and_3d_key.c_str(), "0x34\;ctrl");
     }
     value_size = 0;
-    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", nullptr, &value_size);
+    reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_latency_mode_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", "0x35\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_latency_mode_key.c_str(), "0x35\;ctrl");
     }
 }
 

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -69,16 +69,17 @@ HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Create some default hotkeys.
     try {
         registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
-        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+        registered_hot_keys.push_back(read_from_config(true, "toggle_lens_key", TOGGLE_LENS));
         registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
         registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
         registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
     }
     catch (std::runtime_error &e) {
         // Couldn't find the config value, let's write the default in the .ini
-        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing defaults...";
+        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing/loading defaults...";
         reshade::log_message(reshade::log_level::warning, error_msg.c_str());
         write_missing_hotkeys();
+        load_default_hotkeys();
     }
 }
 
@@ -153,4 +154,13 @@ void HotKeyManager::write_missing_hotkeys() {
     if (value_size <= 0) {
         reshade::set_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", "0x35\;ctrl");
     }
+}
+
+void HotKeyManager::load_default_hotkeys() {
+    registered_hot_keys.erase(registered_hot_keys.begin(), registered_hot_keys.end());
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true));
+    registered_hot_keys.push_back(HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true));
+    registered_hot_keys.push_back(HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true));
 }

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -7,7 +7,7 @@
 
 #include "hotkeyManager.h"
 
-void HotKeyManager::removeUnwantedNulls(std::vector<char>& vec) {
+void HotKeyManager::remove_unwanted_nulls(std::vector<char>& vec) {
     // Find the first occurrence of '\0'
     auto firstNullIt = std::find(vec.begin(), vec.end(), '\0');
 
@@ -32,7 +32,7 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
             std::vector<char> value(value_size);
             reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
             // Remove unwanted '\0' characters as they confuse the string conversion.
-            removeUnwantedNulls(value);
+            remove_unwanted_nulls(value);
             // Convert read value to lower case string
             std::transform(value.begin(), value.end(), value.begin(),
                            [](unsigned char c){ return std::tolower(c); });

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -7,19 +7,56 @@
 
 #include "hotkeyManager.h"
 
-HotKeyManager::HotKeyManager() {
+HotKey HotKeyManager::read_from_config(bool default_enabled, std::string key, shortcutType shortcut) {
+    size_t value_size;
+    reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), nullptr, &value_size);
+    if (value_size > 0) {
+        // Get the value from the config
+        std::vector<char> value(value_size);
+        reshade::get_config_value(nullptr, "3DGameBridge", key.c_str(), value.data(), &value_size);
+        // Convert read value to lower case string
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c){ return std::tolower(c); });
+        std::string str(value.begin(), value.end());
+        // Create the hotkey
+        // Todo: Seems to preemptively split the input on the first ";" already.
+        int found_key = 0;
+        try {
+            // Todo: It should also work if there is not ";" in the config
+            found_key = std::stoi(str.substr(0, str.find(';')));
+        }
+        catch (...)
+        {
+            std::string error_msg = "Unable to read hotkey from config file for hotkey: ";
+            error_msg += key;
+            error_msg += ". Please ensure that you use the keycode table: https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes";
+            reshade::log_message(reshade::log_level::error, error_msg.c_str());
+        }
+        HotKey created_key = HotKey(default_enabled, shortcut, found_key, str.find("shift") != std::string::npos, str.find("alt") != std::string::npos, str.find("ctrl") != str.find("shift") != std::string::npos);
+        return created_key;
+    }
+}
+
+HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Todo: Could be prettier
     // Create some default hotkeys.
-    HotKey toggle_sr_key = HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true);
-    HotKey toggle_lens_key = HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true);
-    HotKey toggle_3d = HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true);
-    HotKey toggle_lens_and_3d = HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true);
-    HotKey toggle_latency_mode = HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true);
-    registered_hot_keys.push_back(toggle_sr_key);
-    registered_hot_keys.push_back(toggle_lens_key);
-    registered_hot_keys.push_back(toggle_3d);
-    registered_hot_keys.push_back(toggle_lens_and_3d);
-    registered_hot_keys.push_back(toggle_latency_mode);
+//    size_t value_size;
+//    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", nullptr, &value_size);
+//    if (value_size > 0) {
+//        std::vector<char> value(value_size);
+//        reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", value.data(), &value_size);
+//    }
+
+//    HotKey toggle_sr_key = HotKey(true, shortcutType::TOGGLE_SR, 0x31, false, false, true);
+//    HotKey toggle_lens_key = HotKey(true, shortcutType::TOGGLE_LENS, 0x32, false, false, true);
+//    HotKey toggle_3d = HotKey(false, shortcutType::TOGGLE_3D, 0x33, false, false, true);
+//    HotKey toggle_lens_and_3d = HotKey(false, shortcutType::TOGGLE_LENS_AND_3D, 0x34, false, false, true);
+//    HotKey toggle_latency_mode = HotKey(false, shortcutType::TOGGLE_LATENCY_MODE, 0x35, false, false, true);
+    registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
+    registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
 }
 
 bool check_modifier_keys(HotKey hotKey, reshade::api::effect_runtime* runtime) {

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -62,15 +62,24 @@ HotKey HotKeyManager::read_from_config(bool default_enabled, const std::string& 
         }
         return created_key;
     }
+    throw std::runtime_error("Unable to read key from config");
 }
 
 HotKeyManager::HotKeyManager(reshade::api::effect_runtime* runtime) {
     // Create some default hotkeys.
-    registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
-    registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+    try {
+        registered_hot_keys.push_back(read_from_config(true, "toggle_sr_key", TOGGLE_SR));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_key", TOGGLE_LENS));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_3d_key", TOGGLE_3D));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_lens_and_3d_key", TOGGLE_LENS_AND_3D));
+        registered_hot_keys.push_back(read_from_config(false, "toggle_latency_mode_key", TOGGLE_LATENCY_MODE));
+    }
+    catch (std::runtime_error &e) {
+        // Couldn't find the config value, let's write the default in the .ini
+        std::string error_msg = "Unable to find hotkey config in ReShade.ini: Now writing defaults...";
+        reshade::log_message(reshade::log_level::warning, error_msg.c_str());
+        write_missing_hotkeys();
+    }
 }
 
 bool check_modifier_keys(HotKey hotKey, reshade::api::effect_runtime* runtime) {
@@ -116,4 +125,32 @@ std::map<shortcutType, bool> HotKeyManager::check_hot_keys(reshade::api::effect_
 
 void HotKeyManager::edit_hot_key(uint8_t hot_key_id) {
 
+}
+
+void HotKeyManager::write_missing_hotkeys() {
+    size_t value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_sr_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_sr_key", "0x31\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_key", "0x32\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_3d_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_3d_key", "0x33\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_lens_and_3d_key", "0x34\;ctrl");
+    }
+    value_size = 0;
+    reshade::get_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", nullptr, &value_size);
+    if (value_size <= 0) {
+        reshade::set_config_value(nullptr, "3DGameBridge", "toggle_latency_mode_key", "0x35\;ctrl");
+    }
 }

--- a/gamebridge_reshade/src/igraphicsapi.cpp
+++ b/gamebridge_reshade/src/igraphicsapi.cpp
@@ -42,11 +42,11 @@ void IGraphicsApi::draw_status_overlay(reshade::api::effect_runtime *runtime) {
     ImGui::TextUnformatted(s.c_str());
 
     // Draw a checkbox and check for changes
+    // This block is executed when the checkbox value is toggled
     if (ImGui::Checkbox("User presence based 3D toggle", &user_presence_3d_toggle_checked))
     {
         ConfigManager::ConfigValue val;
         val.key = "disable_3d_when_no_user_present";
-        // This block is executed when the checkbox value is toggled
         if (user_presence_3d_toggle_checked)
         {
             reshade::log_message(reshade::log_level::info, "User based 3D checkbox enabled");

--- a/gamebridge_reshade/src/igraphicsapi.cpp
+++ b/gamebridge_reshade/src/igraphicsapi.cpp
@@ -7,6 +7,8 @@
 
 #include "igraphicsapi.h"
 
+#include "configManager.h"
+
 /**
  * Takes a major, minor and patch number from ReShade and concatenates them into a single number for easier processing.
  */
@@ -16,4 +18,46 @@ int32_t IGraphicsApi::get_concatinated_reshade_version() {
     result += std::to_string(reshade_version_nr_minor);
     result += std::to_string(reshade_version_nr_patch);
     return std::stoi(result);
+}
+
+void IGraphicsApi::draw_status_overlay(reshade::api::effect_runtime *runtime) {
+    // Log activity status
+    ImGui::TextUnformatted("Status: ACTIVE");
+
+    // Log the latency mode
+    std::string latencyModeDisplay = "Latency mode: ";
+    if (get_latency_mode() == LatencyModes::FRAMERATE_ADAPTIVE) {
+        latencyModeDisplay += "IN " + std::to_string(weaver_latency_in_us) + " MICROSECONDS";
+    }
+    else if (get_latency_mode() == LatencyModes::LATENCY_IN_FRAMES) {
+        latencyModeDisplay += "IN 1 FRAME";
+    }
+    else {
+        latencyModeDisplay += "IN " + std::to_string(runtime->get_back_buffer_count()) + " FRAME(S)";
+    }
+    ImGui::TextUnformatted(latencyModeDisplay.c_str());
+
+    // Log the buffer type, this can be removed once we've tested a larger amount of games.
+    std::string s = "Buffer type: " + std::to_string(static_cast<uint32_t>(current_buffer_format));
+    ImGui::TextUnformatted(s.c_str());
+
+    // Draw a checkbox and check for changes
+    if (ImGui::Checkbox("User presence based 3D toggle", &user_presence_3d_toggle_checked))
+    {
+        ConfigManager::ConfigValue val;
+        val.key = "disable_3d_when_no_user_present";
+        // This block is executed when the checkbox value is toggled
+        if (user_presence_3d_toggle_checked)
+        {
+            reshade::log_message(reshade::log_level::info, "User based 3D checkbox enabled");
+        }
+        else
+        {
+            reshade::log_message(reshade::log_level::info, "User based 3D checkbox disabled");
+        }
+        // Write to config file
+        val.bool_value = user_presence_3d_toggle_checked;
+        val.value_type = ConfigManager::ConfigValue::Type::Bool;
+        ConfigManager::write_config_value(val);
+    }
 }

--- a/gamebridge_reshade/src/igraphicsapi.cpp
+++ b/gamebridge_reshade/src/igraphicsapi.cpp
@@ -61,3 +61,7 @@ void IGraphicsApi::draw_status_overlay(reshade::api::effect_runtime *runtime) {
         ConfigManager::write_config_value(val);
     }
 }
+
+bool IGraphicsApi::is_user_presence_3d_toggle_checked() {
+    return user_presence_3d_toggle_checked;
+}

--- a/gamebridge_reshade/src/igraphicsapi.cpp
+++ b/gamebridge_reshade/src/igraphicsapi.cpp
@@ -65,3 +65,19 @@ void IGraphicsApi::draw_status_overlay(reshade::api::effect_runtime *runtime) {
 bool IGraphicsApi::is_user_presence_3d_toggle_checked() {
     return user_presence_3d_toggle_checked;
 }
+
+void IGraphicsApi::determine_default_latency_mode() {
+    // Check what version of SR we're on, if we're on 1.30 or up, switch to latency in frames.
+    std::string latency_log;
+
+    if (VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 29, 999)) {
+        set_latency_in_frames(-1);
+        latency_log = "Current latency mode set to: LATENCY_IN_FRAMES_AUTOMATIC";
+    } else {
+        // Set mode to latency in frames by default.
+        set_latency_frametime_adaptive(weaver_latency_in_us);
+        latency_log = "Current latency mode set to: STATIC " + std::to_string(weaver_latency_in_us) + " Microseconds";
+    }
+
+    reshade::log_message(reshade::log_level::info, latency_log.c_str());
+}

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -8,6 +8,10 @@
 #pragma once
 
 #include "pch.h"
+#include "VersionComparer.h"
+#include "configManager.h"
+
+#include <sr/version_c.h>
 
 // List of color formats that require color linearization in order restore the correct gamma.
 const std::list<reshade::api::format> srgb_color_formats {

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -34,6 +34,8 @@ struct Destroy_Resource_Data
 };
 
 class IGraphicsApi {
+private:
+    bool user_presence_3d_toggle_checked = ConfigManager::read_from_config("disable_3d_when_no_user_present").bool_value;
 public:
     /// \brief ReShade version numbers read from the appropriate DLL. useful for when certain options only work in certain ReShade versions
     /// These values are set on DLL_ATTACH
@@ -51,7 +53,7 @@ public:
 
     /// \brief A boolean used to determine if the logic for toggling the 3D automatically based on user presence observed by the eye tracker
     /// \return Whether the automatic 3D toggle is enabled or disabled
-    bool user_presence_3d_toggle_checked = false;
+    bool is_user_presence_3d_toggle_checked();
 
     /// \brief Concatenates the reshade_version_nr_major/minor/patch into one number
     /// \return A concatenated ReShade version code without periods. Example: 580 (instead of 5.8.0)

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -63,6 +63,9 @@ public:
     /// \param runtime Represents the reshade effect runtime
     void draw_status_overlay(reshade::api::effect_runtime* runtime);
 
+    /// \brief Checks the current used version of SR, if it is above 1.30, we use latency_in_frames. Otherwise, we use a static latency of 40000 us
+    void determine_default_latency_mode();
+
     /// \brief The main call responsible for weaving the image once ReShade is done drawing effects
     /// \param runtime Represents the reshade effect runtime
     /// \param cmd_list Represents the current command list from ReShade

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -38,6 +38,10 @@ public:
     int32_t reshade_version_nr_minor = 0;
     int32_t reshade_version_nr_patch = 0;
 
+    // Todo: Check this every frame and update the logic based on its state, also write to config
+    // Todo: Doxygen
+    bool user_presence_3d_toggle_checked = false;
+
     /// \brief Concatenates the reshade_version_nr_major/minor/patch into one number
     /// \return A concatenated ReShade version code without periods. Example: 580 (instead of 5.8.0)
     int32_t get_concatinated_reshade_version();

--- a/gamebridge_reshade/src/igraphicsapi.h
+++ b/gamebridge_reshade/src/igraphicsapi.h
@@ -14,7 +14,6 @@ const std::list<reshade::api::format> srgb_color_formats {
     reshade::api::format::r8g8b8a8_unorm_srgb,
 };
 
-const uint32_t default_weaver_latency = 40000;
 // framerateAdaptive = provide an amount of time in microseconds in between weave() calls.
 // latencyInFrames = provide an amount of buffers or "frames" between the application and presenting to the screen.
 // latencyInFramesAutomatic = gets the amount of buffers or "frames" from the backbuffer using the ReShade api every frame.
@@ -38,8 +37,16 @@ public:
     int32_t reshade_version_nr_minor = 0;
     int32_t reshade_version_nr_patch = 0;
 
-    // Todo: Check this every frame and update the logic based on its state, also write to config
-    // Todo: Doxygen
+    /// \brief Weaver eye tracking latency in microseconds. Defaults to 40000us which is tuned for 60Hz screens.
+    /// \return The current weaver latency in us, only used when LatencyMode is set to FRAMERATE_ADAPTIVE
+    uint32_t weaver_latency_in_us = 40000;
+
+    /// \brief ReShade buffer format, used for debugging if we need to use SRGB or RGB buffers for our weaver
+    /// \return The current ReShade buffer format for the active game
+    reshade::api::format current_buffer_format = reshade::api::format::unknown;
+
+    /// \brief A boolean used to determine if the logic for toggling the 3D automatically based on user presence observed by the eye tracker
+    /// \return Whether the automatic 3D toggle is enabled or disabled
     bool user_presence_3d_toggle_checked = false;
 
     /// \brief Concatenates the reshade_version_nr_major/minor/patch into one number
@@ -48,7 +55,7 @@ public:
 
     /// \brief Responsible for drawing debug information in the ImGUI UI
     /// \param runtime Represents the reshade effect runtime
-    virtual void draw_status_overlay(reshade::api::effect_runtime* runtime) = 0;
+    void draw_status_overlay(reshade::api::effect_runtime* runtime);
 
     /// \brief The main call responsible for weaving the image once ReShade is done drawing effects
     /// \param runtime Represents the reshade effect runtime

--- a/gamebridge_reshade/src/systemEventMonitor.cpp
+++ b/gamebridge_reshade/src/systemEventMonitor.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#include "systemEventMonitor.h"
+#include <reshade/include/reshade.hpp>
+#include <sr/sense/core/inputstream.h>
+#include <sr/sense/system/systemeventlistener.h>
+#include <sr/sense/system/systemeventstream.h>
+
+// The accept function can process the system event data as soon as it becomes available
+void SystemEventMonitor::accept(const SR::SystemEvent& frame) {
+    switch (frame.eventType) {
+        case SR_eventType::Info:
+        reshade::log_message(reshade::log_level::info, "Info");
+        break;
+        case SR_eventType::ContextInvalid:
+        // std::string stuff
+        //     << frame.time << " "
+        //     << frame.message << "\n";
+        contextValid = false;
+        break;
+    case SR_eventType::UserLost:
+        // std::cout << "UserLost" << std::endl;
+        isUserLost = true;
+        break;
+    case SR_eventType::UserFound:
+        // std::cout << "UserFound" << std::endl;
+        isUserLost = false;
+        break;
+    default:
+        // std::cout << "Unknown event type" << std::endl;
+        break;
+    }
+}

--- a/gamebridge_reshade/src/systemEventMonitor.cpp
+++ b/gamebridge_reshade/src/systemEventMonitor.cpp
@@ -15,24 +15,18 @@
 void SystemEventMonitor::accept(const SR::SystemEvent& frame) {
     switch (frame.eventType) {
         case SR_eventType::Info:
-        reshade::log_message(reshade::log_level::info, "Info");
-        break;
+            reshade::log_message(reshade::log_level::info, "Info");
+            break;
         case SR_eventType::ContextInvalid:
-        // std::string stuff
-        //     << frame.time << " "
-        //     << frame.message << "\n";
-        contextValid = false;
-        break;
-    case SR_eventType::UserLost:
-        // std::cout << "UserLost" << std::endl;
-        isUserLost = true;
-        break;
-    case SR_eventType::UserFound:
-        // std::cout << "UserFound" << std::endl;
-        isUserLost = false;
-        break;
-    default:
-        // std::cout << "Unknown event type" << std::endl;
-        break;
+            contextValid = false;
+            break;
+        case SR_eventType::UserLost:
+            isUserLost = true;
+            break;
+        case SR_eventType::UserFound:
+            isUserLost = false;
+            break;
+        default:
+            break;
     }
 }

--- a/gamebridge_reshade/src/systemEventMonitor.h
+++ b/gamebridge_reshade/src/systemEventMonitor.h
@@ -1,0 +1,29 @@
+/*
+ * This file falls under the GNU General Public License v3.0 license: See the LICENSE.txt in the root of this project for more info.
+ * Summary:
+ * Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license.
+ * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
+ */
+
+#ifndef SYSTEMEVENTMONITOR_H
+#define SYSTEMEVENTMONITOR_H
+#include <sr/sense/core/inputstream.h>
+#include <sr/sense/system/systemevent.h>
+#include <sr/sense/system/systemeventlistener.h>
+#include <sr/sense/system/systemeventstream.h>
+
+class SystemEventMonitor : public SR::SystemEventListener {
+public:
+    virtual ~SystemEventMonitor() = default;
+
+    // Ensures SystemEventStream is cleaned up when Listener object is out of scope
+    SR::InputStream<SR::SystemEventStream> stream;
+
+    // Flag to indicate that context is no longer valid
+    bool contextValid = true;
+    bool isUserLost = true;
+
+    void accept(const SR::SystemEvent& frame) override;
+};
+
+#endif //SYSTEMEVENTMONITOR_H

--- a/gamebridge_reshade/src/systemEventMonitor.h
+++ b/gamebridge_reshade/src/systemEventMonitor.h
@@ -5,8 +5,8 @@
  * Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. Modifications to the source code must be disclosed publicly.
  */
 
-#ifndef SYSTEMEVENTMONITOR_H
-#define SYSTEMEVENTMONITOR_H
+#pragma once
+
 #include <sr/sense/core/inputstream.h>
 #include <sr/sense/system/systemevent.h>
 #include <sr/sense/system/systemeventlistener.h>
@@ -25,5 +25,3 @@ public:
 
     void accept(const SR::SystemEvent& frame) override;
 };
-
-#endif //SYSTEMEVENTMONITOR_H

--- a/gamebridge_reshade/src/systemEventMonitor.h
+++ b/gamebridge_reshade/src/systemEventMonitor.h
@@ -21,7 +21,7 @@ public:
 
     // Flag to indicate that context is no longer valid
     bool contextValid = true;
-    bool isUserLost = true;
+    bool isUserLost = false;
 
     void accept(const SR::SystemEvent& frame) override;
 };


### PR DESCRIPTION
To test:
- [x] Configurable hotkeys in .ini
- [x] Loading app without any hotkeys configured
- [x] Auto weaver toggle when user is not visible
- [x] Disabling/enabling auto weaver toggle in overlay
- [x] Changing the setting for the auto weaver toggle in the .ini prior to launching the app
- [x] Changes to weaver toggle from the overlay persisting into .ini file
- [x] SRGB buffer corruption in Last of Us/RE4 Remake > Fix by passing the SRGB buffer from ReShade into the new SR API for the weaver
- [x] Verify fixes for eye tracker bugs in platform
- [x] Test all graphics APIs