### PR TITLE
Fix/investigate scissor/stencil/blend test OpenGL

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -2,5 +2,6 @@ cmake_minimum_required(VERSION 3.23)
 project (GameBridgeProjects VERSION 0.1)
 
 set (CMAKE_CXX_STANDARD 20)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(gamebridge_reshade)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,14 +85,14 @@ These bindings look like this:
 
 ``` .ini
 [3DGameBridge]
-toggle_3d_key=0x33;ctrl
-toggle_latency_mode_key=0x35;ctrl
-toggle_lens_and_3d_key=0x34;ctrl
-toggle_lens_key=0x32;ctrl
-toggle_sr_key=0x31;ctrl;shift;alt
+toggle_3d_key=0x33\;ctrl
+toggle_latency_mode_key=0x35\;ctrl
+toggle_lens_and_3d_key=0x34\;ctrl
+toggle_lens_key=0x32\;ctrl
+toggle_sr_key=0x31\;ctrl\;shift\;alt
 ```
 
-Key bindings are structured like this:<br/> `[hex_keycode];[modifier_key];[modifier_key];[modifier_key]`<br/>
+Key bindings are structured like this:<br/> `[hex_keycode]\;[modifier_key]\;[modifier_key]\;[modifier_key]`<br/>
 - The supported keycodes can be found in the "value" column [here](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes).
 - The supported modifier keys are: `shift`, `ctrl` and `alt`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ This version is **lacking** some of our planned quality of life features. Furthe
 5. *“The addon is loaded in ReShade and the game is SBS, but it doesn’t turn 3D on\!”*
 
    Make sure your SR device is fully connected. That means that the computer must have a USB connection and a display connection to the screen.   
-6. This version of the addon is only tested for ReShade version 6.2.0. API changes on ReShade’s side may make our addon incompatible with newer versions. This version of the addon has only been tested with SR Platform version 1.30.x- 1.31.1. It is possible that future versions of the platform will be incompatible with this addon.   
+6. This version of the addon is only tested for ReShade version 6.2.0. API changes on ReShade’s side may make our addon incompatible with newer versions. This version of the addon has only been tested with SR Platform version 1.30.x- 1.34.7. It is possible that future versions of the platform will be incompatible with this addon.   
      
    If you run into any dependency related problems, you can consider messaging @dinnerbram or @janthony102 on Discord. We can see if we can help resolve your problem, but we are making no promises, and we are under no obligation to do so. We hope you understand as we are spreading ourselves quite thin already. 
 

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -10,7 +10,7 @@ elseif (WIN32)
 endif ()
 
 # Define LINK_GLAD
-option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged in SR version 1.30.x and up. Either downgrade to 1.30.x or set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
+option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged between SR version 1.30.x - 1.34.x. Either downgrade to 1.30.x or update to 1.34.x+ and set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
 
 if (LINK_GLAD)
 	add_compile_definitions(ENABLE_GLAD)

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -1,18 +1,12 @@
 cmake_minimum_required(VERSION 3.23)
 project (GameBridgeReshade VERSION 0.1)
 
+# Tell CMake to look here for find_package() based on system architecture.
 if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
 	set(BUILD_PLATFORM 32)
-	set(LEIASR_SDKROOT32 "$ENV{LEIASR_SDKROOT32}" CACHE PATH "Path to LEIASR SDK root")
-else ()
-	set(LEIASR_SDKROOT "$ENV{LEIASR_SDKROOT}" CACHE PATH "Path to LEIASR SDK root")
-endif ()
-
-# Tell CMake to look here for find_package()
-if (LEIASR_SDKROOT)
-	list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT}/lib/cmake")
-elseif (LEIASR_SDKROOT32)
-	list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT32}/lib/cmake")
+	list(APPEND CMAKE_PREFIX_PATH "$ENV{LEIASR_SDKROOT32}/lib/cmake")
+elseif (WIN32)
+	list(APPEND CMAKE_PREFIX_PATH "$ENV{LEIASR_SDKROOT}/lib/cmake")
 endif ()
 
 # Define LINK_GLAD

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -82,7 +82,7 @@ find_package(srOpenGL REQUIRED)
 # Rename dll with extension .addon
 add_custom_command(
 	TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND}
-	ARGS -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>/${ADDON_FILE_NAME}.addon
+	ARGS -E copy_if_different $<TARGET_FILE:${PROJECT_NAME}> $<TARGET_FILE_DIR:${PROJECT_NAME}>/${ADDON_FILE_NAME}.addon${BUILD_PLATFORM}
 )
 
 # Copy dll to reshade directory

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -9,6 +9,10 @@ elseif (WIN32)
 	list(APPEND CMAKE_PREFIX_PATH "$ENV{LEIASR_SDKROOT}/lib/cmake")
 endif ()
 
+# set language to c++-17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Define LINK_GLAD
 option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged in SR version 1.30.x and up. Either downgrade to 1.30.x or set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
 

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -9,10 +9,6 @@ elseif (WIN32)
 	list(APPEND CMAKE_PREFIX_PATH "$ENV{LEIASR_SDKROOT}/lib/cmake")
 endif ()
 
-# set language to c++-17
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Define LINK_GLAD
 option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged in SR version 1.30.x and up. Either downgrade to 1.30.x or set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
 

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.23)
 project (GameBridgeReshade VERSION 0.1)
 
+set(LEIASR_SDKROOT "$ENV{LEIASR_SDKROOT}" CACHE PATH "Path to LEIASR SDK root")
+set(LEIASR_SDKROOT32 "$ENV{LEIASR_SDKROOT32}" CACHE PATH "Path to LEIASR SDK root")
+
+# Tell CMake to look here for find_package()
+list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT}/lib/cmake")
+list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT32}/lib/cmake")
+
 # Define LINK_GLAD
 option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged in SR version 1.30.x and up. Either downgrade to 1.30.x or set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
 

--- a/gamebridge_reshade/CMakelists.txt
+++ b/gamebridge_reshade/CMakelists.txt
@@ -1,24 +1,31 @@
 cmake_minimum_required(VERSION 3.23)
 project (GameBridgeReshade VERSION 0.1)
 
-set(LEIASR_SDKROOT "$ENV{LEIASR_SDKROOT}" CACHE PATH "Path to LEIASR SDK root")
-set(LEIASR_SDKROOT32 "$ENV{LEIASR_SDKROOT32}" CACHE PATH "Path to LEIASR SDK root")
+if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+	set(BUILD_PLATFORM 32)
+	set(LEIASR_SDKROOT32 "$ENV{LEIASR_SDKROOT32}" CACHE PATH "Path to LEIASR SDK root")
+else ()
+	set(LEIASR_SDKROOT "$ENV{LEIASR_SDKROOT}" CACHE PATH "Path to LEIASR SDK root")
+endif ()
 
 # Tell CMake to look here for find_package()
-list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT}/lib/cmake")
-list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT32}/lib/cmake")
+if (LEIASR_SDKROOT)
+	list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT}/lib/cmake")
+elseif (LEIASR_SDKROOT32)
+	list(APPEND CMAKE_PREFIX_PATH "${LEIASR_SDKROOT32}/lib/cmake")
+endif ()
 
 # Define LINK_GLAD
 option(LINK_GLAD "Link the glad OpenGL loader. 3D in OpenGL is bugged in SR version 1.30.x and up. Either downgrade to 1.30.x or set up GLAD in the `third-party/glad` folder and enable this flag." OFF)
 
-if(LINK_GLAD)
+if (LINK_GLAD)
 	add_compile_definitions(ENABLE_GLAD)
 	set(GLAD_DIR ${CMAKE_SOURCE_DIR}/gamebridge_reshade/third-party/glad)
 	set(GLAD_SOURCE
 			${GLAD_DIR}/src/gl.c
 			${GLAD_DIR}/include/glad/gl.h
 	)
-endif()
+endif ()
 
 add_library(${PROJECT_NAME} SHARED
     src/dllmain.cpp
@@ -54,13 +61,9 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 # Add glad includes only if LINK_GLAD is enabled
-if(LINK_GLAD)
+if (LINK_GLAD)
 	target_include_directories(${PROJECT_NAME} PRIVATE ${GLAD_DIR}/include)
-endif()
-
-if (WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-	set(BUILD_PLATFORM 32)
-endif()
+endif ()
 
 # Set output name for the addon
 set(ADDON_FILE_NAME "srReshade")
@@ -90,14 +93,14 @@ add_custom_command(
 
 # Copy dll to reshade directory
 set(ADDON_COPY_DIR "" CACHE STRING "Path where the .addon file will be copied to on successful build")
-if(NOT ${ADDON_COPY_DIR} STREQUAL "")
+if (NOT ${ADDON_COPY_DIR} STREQUAL "")
 	add_custom_command(
 		TARGET ${PROJECT_NAME} POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E make_directory ${ADDON_COPY_DIR}
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE_DIR:${PROJECT_NAME}>/${ADDON_FILE_NAME}.addon ${ADDON_COPY_DIR}
 	)
 	message("Addon will be copied to ${ADDON_COPY_DIR}")
-endif()
+endif ()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
 		delayimp

--- a/gamebridge_reshade/src/VersionComparer.cpp
+++ b/gamebridge_reshade/src/VersionComparer.cpp
@@ -11,6 +11,15 @@
 #include <string>
 #include <vector>
 
+/**
+ * Checks if the running version is newer than the specified version.
+ *
+ * @param runningVersionString The current running version string (e.g. "1.2.3").
+ * @param major The major version number to compare against.
+ * @param minor The minor version number to compare against.
+ * @param patch The patch version number to compare against.
+ * @return True if the running version is newer, false otherwise.
+ */
 bool VersionComparer::is_version_newer(const char *runningVersionString, int major, int minor, int patch) {
     // Parse the version string
     std::string version(runningVersionString);

--- a/gamebridge_reshade/src/configManager.cpp
+++ b/gamebridge_reshade/src/configManager.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <algorithm>
+#include <cctype>
 #include <stdexcept>
 #include <vector>
 #include <reshade/include/reshade.hpp>
@@ -71,7 +72,7 @@ ConfigManager::ConfigValue ConfigManager::read_from_config(const std::string &ke
             remove_unwanted_nulls(value);
             // Convert read value to lower case string
             std::transform(value.begin(), value.end(), value.begin(),
-                           [](unsigned char c){ return std::tolower(c); });
+                           [](unsigned char c){ return tolower(c); });
             std::string str(value.begin(), value.end());
             // Try parsing as boolean
             if (str == "true") {

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -401,7 +401,7 @@ static void on_destroy_effect_runtime(reshade::api::effect_runtime* runtime) {
 // Track device destruction as a stronger signal of process exit or teardown
 static void on_destroy_device(reshade::api::device* device) {
     device_destroyed.store(true, std::memory_order_release);
-    // Todo: We are fairly sure this code block always returns true at this point but we need to double check so we can remove this later.
+    // We are fairly sure this code block always returns true but in the case where there are multiple devices, this check is necessary.
     if (active_effect_runtimes.load(std::memory_order_acquire) == 0) {
         std::call_once(exit_cleanup_once, []() {
             perform_exit_cleanup();

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -401,6 +401,7 @@ static void on_destroy_effect_runtime(reshade::api::effect_runtime* runtime) {
 // Track device destruction as a stronger signal of process exit or teardown
 static void on_destroy_device(reshade::api::device* device) {
     device_destroyed.store(true, std::memory_order_release);
+    // Todo: We are fairly sure this code block always returns true at this point but we need to double check so we can remove this later.
     if (active_effect_runtimes.load(std::memory_order_acquire) == 0) {
         std::call_once(exit_cleanup_once, []() {
             perform_exit_cleanup();
@@ -420,6 +421,7 @@ static void perform_exit_cleanup() {
     }
     reshade::log_message(reshade::log_level::info, "Weaver destructed.");
 
+    // Todo: We may not need to delete the sr_context, deleting the weaver object might be enough.
     if (sr_context) {
         delete sr_context;
         sr_context = nullptr;

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -57,7 +57,7 @@ static size_t char_buffer_size = CHAR_BUFFER_SIZE;
 static bool sr_initialized = false;
 static bool user_lost_grace_period_active = false;
 static bool user_lost_logic_enabled = false;
-static bool is_potentially_unstable_opengl_version = false;
+static bool enable_compatibility_mode = false;
 static int user_lost_additional_grace_period_duration_in_ms = 0;
 static chrono::steady_clock::time_point user_lost_timestamp;
 
@@ -343,10 +343,10 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
                     }
 #endif
                     // Check if SR version > 1.30.x and < 1.34.x. If so, OpenGL is potentially bugged.
-                    // Use this version check to enable/disable our OpenGL fix once Leia includes a fix in their official platform.
-                    is_potentially_unstable_opengl_version = VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 30, 999) &&
+                    // Use this version check to enable/disable our OpenGL fix. Leia includes a fix in their official platform in newer versions.
+                    enable_compatibility_mode = VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 30, 999) &&
                                                              !VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 33, 999);
-                    weaver_implementation = new OpenGLWeaver(sr_context, is_potentially_unstable_opengl_version);
+                    weaver_implementation = new OpenGLWeaver(sr_context, enable_compatibility_mode);
                     break;
                 case reshade::api::device_api::d3d9:
                     weaver_implementation = new DirectX9Weaver(sr_context);

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -342,11 +342,11 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
                         reshade::log_message(reshade::log_level::error, "Unable to load GLAD. Weaving may be incorrect between SR versions 1.30.x and 1.33.2");
                     }
 #endif
-
-                    weaver_implementation = new OpenGLWeaver(sr_context);
-                    // Check if SR version > 1.30.x. If so, OpenGL is potentially bugged.
-                    // Todo: Use this version check to enable/disable our OpenGL fix once Leia includes a fix in their official platform.
-                    is_potentially_unstable_opengl_version = VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 30, 999);
+                    // Check if SR version > 1.30.x and < 1.34.x. If so, OpenGL is potentially bugged.
+                    // Use this version check to enable/disable our OpenGL fix once Leia includes a fix in their official platform.
+                    is_potentially_unstable_opengl_version = VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 30, 999) &&
+                                                             !VersionComparer::is_version_newer(getSRPlatformVersion(), 1, 33, 999);
+                    weaver_implementation = new OpenGLWeaver(sr_context, is_potentially_unstable_opengl_version);
                     break;
                 case reshade::api::device_api::d3d9:
                     weaver_implementation = new DirectX9Weaver(sr_context);

--- a/gamebridge_reshade/src/dllmain.cpp
+++ b/gamebridge_reshade/src/dllmain.cpp
@@ -28,6 +28,8 @@
 #include <thread>
 #include <vector>
 #include <iostream>
+#include <atomic>
+#include <mutex>
 #include <sr/sense/system/systemsense.h>
 #ifdef ENABLE_GLAD
 #include <glad/gl.h>
@@ -59,9 +61,17 @@ static bool is_potentially_unstable_opengl_version = false;
 static int user_lost_additional_grace_period_duration_in_ms = 0;
 static chrono::steady_clock::time_point user_lost_timestamp;
 
+// Runtime & device lifecycle tracking
+static std::atomic<int> active_effect_runtimes{0};
+static std::once_flag exit_cleanup_once;
+static std::atomic<bool> device_destroyed{false};
+
 std::vector<LPCWSTR> reshade_dll_names =  { L"dxgi.dll", L"ReShade.dll", L"ReShade64.dll", L"ReShade32.dll", L"d3d9.dll", L"d3d10.dll", L"d3d11.dll", L"d3d12.dll", L"opengl32.dll" };
 
 void deregisterCallbacksOnDllLoadFailure();
+
+// Forward declare new helpers
+static void perform_exit_cleanup();
 
 // Function to get the version information of a module
 vector<size_t> get_module_version_info(LPCWSTR moduleName) {
@@ -151,13 +161,8 @@ static void execute_hot_key_function_by_type(std::map<shortcutType, bool> hot_ke
                 }
             });
 
-            for (int effect_iterator = 0; effect_iterator < togglable_3D_effects.size(); effect_iterator++) {
-                if (i->second) {
-                    runtime->set_technique_state(togglable_3D_effects[effect_iterator], true);
-                }
-                else {
-                    runtime->set_technique_state(togglable_3D_effects[effect_iterator], false);
-                }
+            for (size_t effect_iterator = 0; effect_iterator < togglable_3D_effects.size(); effect_iterator++) {
+                runtime->set_technique_state(togglable_3D_effects[effect_iterator], i->second);
             }
             break;
         case shortcutType::TOGGLE_LENS_AND_3D:
@@ -276,7 +281,7 @@ static bool init_sr() {
                 return false;
             }
         }
-        catch (SR::ServerNotAvailableException& ex) {
+        catch (SR::ServerNotAvailableException&) {
             // Unable to construct SR Context.
             reshade::log_message(reshade::log_level::error, "Unable to connect to the SR Service, make sure the SR Platform is installed and running.");
             sr_initialized = false;
@@ -302,6 +307,8 @@ static bool init_sr() {
 }
 
 static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
+    active_effect_runtimes.fetch_add(1, std::memory_order_relaxed);
+
     // Catch any runtime_error which points to not all required DLLs being present.
     if (!init_sr()) {
         return;
@@ -315,7 +322,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     // Read config values from .ini
     if (config_manager == nullptr) {
         config_manager = new ConfigManager();
-        for (int i = 0; i < config_manager->registered_config_values.size(); i++) {
+        for (size_t i = 0; i < config_manager->registered_config_values.size(); i++) {
             if (config_manager->registered_config_values[i].key == gb_config_disable_3d_when_no_user) {
                 user_lost_logic_enabled = config_manager->registered_config_values[i].bool_value;
             }
@@ -367,7 +374,7 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     }
 
     // Get ReShade version number
-    for (int i = 0; i < reshade_dll_names.size(); i++) {
+    for (size_t i = 0; i < reshade_dll_names.size(); i++) {
         std::vector<size_t> version_nrs = get_module_version_info(reshade_dll_names[i]);
         if (version_nrs.size() == 3) {
             weaver_implementation->reshade_version_nr_major = version_nrs[0];
@@ -380,6 +387,47 @@ static void on_init_effect_runtime(reshade::api::effect_runtime* runtime) {
     weaver_implementation->on_init_effect_runtime(runtime);
 }
 
+// Called when an effect runtime is destroyed (can happen multiple times)
+static void on_destroy_effect_runtime(reshade::api::effect_runtime* runtime) {
+    int remaining = active_effect_runtimes.fetch_sub(1, std::memory_order_acq_rel) - 1;
+    // Only consider triggering cleanup if device already gone or this was last runtime
+    if (remaining <= 0 && device_destroyed.load(std::memory_order_acquire)) {
+        std::call_once(exit_cleanup_once, []() {
+            perform_exit_cleanup();
+        });
+    }
+}
+
+// Track device destruction as a stronger signal of process exit or teardown
+static void on_destroy_device(reshade::api::device* device) {
+    device_destroyed.store(true, std::memory_order_release);
+    if (active_effect_runtimes.load(std::memory_order_acquire) == 0) {
+        std::call_once(exit_cleanup_once, []() {
+            perform_exit_cleanup();
+        });
+    }
+}
+
+static void perform_exit_cleanup() {
+    reshade::log_message(reshade::log_level::info, "Performing exit cleanup.");
+
+    // Stop using weaver_implementation with ReShade now
+    if (weaver_implementation) {
+        // If there is a custom shutdown method, call it (example):
+        // weaver_implementation->shutdown();
+        delete weaver_implementation;
+        weaver_implementation = nullptr;
+    }
+    reshade::log_message(reshade::log_level::info, "Weaver destructed.");
+
+    if (sr_context) {
+        delete sr_context;
+        sr_context = nullptr;
+    }
+
+    reshade::log_message(reshade::log_level::info, "Exit cleanup complete.");
+}
+
 void deregisterCallbacksOnDllLoadFailure() {
     // Mark the dll_failed_to_load status
     dll_failed_to_load = true;
@@ -387,6 +435,8 @@ void deregisterCallbacksOnDllLoadFailure() {
     // Unregister all events
     reshade::unregister_event<reshade::addon_event::reshade_finish_effects>(&on_reshade_finish_effects);
     reshade::unregister_event<reshade::addon_event::init_effect_runtime>(&on_init_effect_runtime);
+    reshade::unregister_event<reshade::addon_event::destroy_effect_runtime>(&on_destroy_effect_runtime);
+    reshade::unregister_event<reshade::addon_event::destroy_device>(&on_destroy_device);
 }
 
 BOOL APIENTRY DllMain( HMODULE hModule,
@@ -402,11 +452,16 @@ BOOL APIENTRY DllMain( HMODULE hModule,
             return FALSE;
 
         reshade::register_event<reshade::addon_event::init_effect_runtime>(&on_init_effect_runtime);
+        reshade::register_event<reshade::addon_event::destroy_effect_runtime>(&on_destroy_effect_runtime);
         reshade::register_event<reshade::addon_event::reshade_finish_effects>(&on_reshade_finish_effects);
+        reshade::register_event<reshade::addon_event::destroy_device>(&on_destroy_device);
         reshade::register_overlay(nullptr, &draw_status_overlay);
-
         break;
     case DLL_PROCESS_DETACH:
+        // Fallback: ensure cleanup ran (avoid heavy operations here).
+        std::call_once(exit_cleanup_once, []() {
+            perform_exit_cleanup();
+        });
         reshade::unregister_addon(hModule);
         break;
     }

--- a/gamebridge_reshade/src/hotkeymanager.cpp
+++ b/gamebridge_reshade/src/hotkeymanager.cpp
@@ -133,27 +133,27 @@ void HotKeyManager::write_missing_hotkeys() {
     size_t value_size = 0;
     reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_sr_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_sr_key.c_str(), "0x31\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_sr_key.c_str(), "0x31\\;ctrl");
     }
     value_size = 0;
     reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_key.c_str(), "0x32\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_key.c_str(), "0x32\\;ctrl");
     }
     value_size = 0;
     reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_3d_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_3d_key.c_str(), "0x33\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_3d_key.c_str(), "0x33\\;ctrl");
     }
     value_size = 0;
     reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_and_3d_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_and_3d_key.c_str(), "0x34\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_lens_and_3d_key.c_str(), "0x34\\;ctrl");
     }
     value_size = 0;
     reshade::get_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_latency_mode_key.c_str(), nullptr, &value_size);
     if (value_size <= 0) {
-        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_latency_mode_key.c_str(), "0x35\;ctrl");
+        reshade::set_config_value(nullptr, gb_config_section_name.c_str(), gb_config_toggle_latency_mode_key.c_str(), "0x35\\;ctrl");
     }
 }
 

--- a/gamebridge_reshade/src/openglweaver.cpp
+++ b/gamebridge_reshade/src/openglweaver.cpp
@@ -157,6 +157,14 @@ GbResult OpenGLWeaver::on_reshade_finish_effects(reshade::api::effect_runtime* r
     };
     cmd_list->bind_viewports(0, 1, &viewport);
 
+    // Bind a scissor rect that covers the entire render target
+    const reshade::api::rect scissor_rect = {
+            0, 0,
+            static_cast<int32_t>(desc.texture.width),
+            static_cast<int32_t>(desc.texture.height)
+    };
+    cmd_list->bind_scissor_rects(0, 1, &scissor_rect);
+
     if (weaver_initialized) {
         // Check if we need to set the latency in frames.
         if (get_latency_mode() == LatencyModes::LATENCY_IN_FRAMES_AUTOMATIC) {

--- a/gamebridge_reshade/src/openglweaver.cpp
+++ b/gamebridge_reshade/src/openglweaver.cpp
@@ -10,11 +10,11 @@
 #include <glad/gl.h>
 #endif
 
-OpenGLWeaver::OpenGLWeaver(SR::SRContext* context, bool is_potentially_unstable_opengl_version) {
+OpenGLWeaver::OpenGLWeaver(SR::SRContext* context, bool enable_compatibility_mode) {
     // Set context here.
     sr_context = context;
     weaving_enabled = true;
-    requires_sampler_binding_code_opengl = is_potentially_unstable_opengl_version;
+    requires_sampler_binding_code_opengl = enable_compatibility_mode;
 }
 
 void OpenGLWeaver::flip_buffer(int buffer_height, int buffer_width, reshade::api::command_list* cmd_list, reshade::api::resource source, reshade::api::resource dest) {
@@ -209,7 +209,7 @@ GbResult OpenGLWeaver::on_reshade_finish_effects(reshade::api::effect_runtime* r
                     glDisable(GL_BLEND);
 
 
-                // The specific bind/unbind code below should be surrounded by an if-statement based on the SR version that's active. If below the version that fixes this internally, it should not be run. Version which has the fix is 1.34.0.
+                // The specific bind/unbind code below is surrounded by an if-statement based on the SR version that's active. If below the version that fixes this internally, it should not be run. Version which has the fix is 1.34.0.
                 GLint prevSamplerBinding0;
                 GLint prevSamplerBinding1;
                 GLint prevSamplerBinding2;

--- a/gamebridge_reshade/src/openglweaver.h
+++ b/gamebridge_reshade/src/openglweaver.h
@@ -20,6 +20,7 @@ class OpenGLWeaver: public IGraphicsApi {
     bool popup_window_visible = false;
     bool resize_buffer_failed = false;
     bool use_srgb_rtv = false;
+    bool requires_sampler_binding_code_opengl = false;
 
     float view_separation = 0.f;
     float vertical_shift = 0.f;
@@ -48,7 +49,7 @@ class OpenGLWeaver: public IGraphicsApi {
 public:
     /// \brief Explicit constructor
     /// \param context Pointer to an already initialized SRContext
-    explicit OpenGLWeaver(SR::SRContext* context);
+    explicit OpenGLWeaver(SR::SRContext* context, bool is_potentially_unstable_opengl_version);
 
     /// \brief Initialized the SR weaver appropriate for the graphics API
     /// \param runtime Represents the reshade effect runtime

--- a/gamebridge_reshade/src/openglweaver.h
+++ b/gamebridge_reshade/src/openglweaver.h
@@ -49,7 +49,7 @@ class OpenGLWeaver: public IGraphicsApi {
 public:
     /// \brief Explicit constructor
     /// \param context Pointer to an already initialized SRContext
-    /// \param enable_compatibility_mode Value which determines if the version of the SR platform used can cause issues in OpenGL titles.
+    /// \param enable_compatibility_mode This value should be true if the version of the SR platform used can cause issues in OpenGL applications.
     explicit OpenGLWeaver(SR::SRContext* context, bool enable_compatibility_mode);
 
     /// \brief Initialized the SR weaver appropriate for the graphics API

--- a/gamebridge_reshade/src/openglweaver.h
+++ b/gamebridge_reshade/src/openglweaver.h
@@ -49,7 +49,8 @@ class OpenGLWeaver: public IGraphicsApi {
 public:
     /// \brief Explicit constructor
     /// \param context Pointer to an already initialized SRContext
-    explicit OpenGLWeaver(SR::SRContext* context, bool is_potentially_unstable_opengl_version);
+    /// \param enable_compatibility_mode Value which determines if the version of the SR platform used can cause issues in OpenGL titles.
+    explicit OpenGLWeaver(SR::SRContext* context, bool enable_compatibility_mode);
 
     /// \brief Initialized the SR weaver appropriate for the graphics API
     /// \param runtime Represents the reshade effect runtime


### PR DESCRIPTION
Todo:
- [x] Add logic to disable/enable the sampler state binding based on SR SDK version (lower than 1.34.0 means it's enabled).
- [x] Update docs to refer to 1.34.7 as the target version of this software
- [x] Test and ensure that the DX9 constructor used is still working in this version of the addon. Otherwise, add an ifdef there that changes it to a different one if the installed platform is newer than 1.32.7.
- [x] Solve this issue with the advice Crosire provided: https://github.com/BramTeurlings/3DGameBridge/issues/186 > Solved by including `SR.addonfx` to `reshade-shaders/Shaders` on release.

PR's to Merge:
- [x] https://github.com/JoeyAnthony/3DGameBridgeProjects/pull/32
- [x] https://github.com/JoeyAnthony/3DGameBridgeProjects/pull/33
- [x] https://github.com/JoeyAnthony/3DGameBridgeProjects/pull/34